### PR TITLE
Fix: render layers method. Cancel promises. Esri z-index

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "extends": "vizzuality",
   "rules": {
+    "no-debugger": 0
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/src/layers/carto-layer/carto-layer-gmaps.js
+++ b/src/layers/carto-layer/carto-layer-gmaps.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import cartoService from './carto-layer-service';
 
 const CartoLayer = (layerSpec) => {

--- a/src/layers/carto-layer/carto-layer-leaflet.js
+++ b/src/layers/carto-layer/carto-layer-leaflet.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import cartoService from './carto-layer-service';
 
 const CartoLayer = (layerModel) => {

--- a/src/layers/esri-layer/esri-layer-leaflet.js
+++ b/src/layers/esri-layer/esri-layer-leaflet.js
@@ -23,13 +23,22 @@ const esriLayer = (layerModel) => {
 
     const layer = L.esri[layerConfig.type](layerOptions);
 
-    layer.on('requesterror', err => console.error(err));
+    if (layer) {
+      // Little hack to set zIndex at the beginning
+      layer.on('load', () => {
+        layer.setZIndex(layerModel.get('zIndex'));
+      });
 
-    // adding setZIndex method to layer instance
+      layer.on('requesterror', err => console.error(err));
+    } else {
+      return reject();
+    }
+
     if (!layer.setZIndex) {
       layer.setZIndex = (zIndex) => {
-      // I didn't manage to change the zIndex in Esri layers.
-      // It doesn't have a proper solution rather than panes, which won't work with our current aproach...
+        if (layer._currentImage) {
+          layer._currentImage._image.style.zIndex = zIndex;
+        }
       };
     }
 


### PR DESCRIPTION
- Fix: render layers method allow promise cancelation.
- Fix: Esri zIndex now working