### PR TITLE
fix: react components async props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,9 @@
   "extends": "vizzuality",
   "rules": {
     "no-debugger": 0,
-    "class-methods-use-this": 0
+    "class-methods-use-this": 0,
+    "react/prop-types": 0,
+    "react/sort-comp": 0
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -39,17 +39,13 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "leaflet": "^1.3.1",
-    "lodash": "^4.17.5",
     "wri-json-api-serializer": "^1.0.1"
   },
-  "peerDependencies": {
-    "leaflet": "^1.3.1"
-  },
   "engines": {
-    "node": "8.11.x"
+    "node": ">=8.11.x"
   },
   "optionalDependencies": {
-    "react": ">=15.0.0"
+    "react": ">=15.0.0",
+    "leaflet": "^1.3.1"
   }
 }

--- a/src/react/layer-manager.js
+++ b/src/react/layer-manager.js
@@ -3,8 +3,9 @@ import React, { Component } from 'react';
 import Manager from '../layer-manager';
 
 class LayerManager extends Component {
-  componentDidMount() {
-    const { map, plugin, options } = this.props;
+  constructor(props) {
+    super(props);
+    const { map, plugin, options } = props;
     this.layerManager = new Manager(map, plugin, options);
   }
 


### PR DESCRIPTION
So `componentDidMount` executes in a bottom to top fashion, only after all of the component's children have executed their `componentDidMount`. The instantiation of LayerManager class inside `<LayerManager />`'s componentDidMount in some cases can happen after the `<Layer />`'s componentDidMount so it crashed.

This fixes that, removes the annoying node dependency and unused dependencies too.