### PR TITLE
Feature/engine fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "wri-json-api-serializer": "^1.0.1"
   },
   "engines": {
-    "node": ">=8.11.x"
+    "node": ">=8.x.x"
   },
   "optionalDependencies": {
     "leaflet": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer-manager",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A library to get a layer depending on provider and layer spec",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
In some projects, we still have a node version minor than `8.11.0`, and as I checked it works with any version of node 8. So I've changed the engine requires to accept all node 8 versions.