### PR TITLE
Allows passing a function as children

### DIFF
--- a/src/react/layer-manager.js
+++ b/src/react/layer-manager.js
@@ -12,15 +12,17 @@ class LayerManager extends Component {
     plugin: PropTypes.func,
     layersSpec: PropTypes.arrayOf(PropTypes.object),
     onLayerLoading: PropTypes.func,
-    children: PropTypes.arrayOf(PropTypes.node)
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.func
+    ])
   };
 
   static defaultProps = {
     plugin: PluginLeaflet,
     children: [],
     layersSpec: [],
-    onLayerLoading: () => {
-    }
+    onLayerLoading: () => {}
   };
 
   constructor(props) {
@@ -31,6 +33,10 @@ class LayerManager extends Component {
 
   render() {
     const { children, layersSpec, onLayerLoading } = this.props;
+
+    if (children && typeof children === 'function') {
+      return children(this.layerManager);
+    }
 
     if (Children.count(children)) {
       return Children.map(

--- a/src/react/layer.js
+++ b/src/react/layer.js
@@ -10,8 +10,7 @@ class Layer extends Component {
   };
 
   static defaultProps = {
-    onLayerLoading: () => {
-    }
+    onLayerLoading: () => {}
   };
 
   componentDidMount() {


### PR DESCRIPTION
Allows the children to return a function that contains an instance of the `layerManager`. This way, the application can pass the `layerManager` prop to the `Layer` component and avoid the undefined prop warning.