### PR TITLE
Feature/allow arrays in sql config

### DIFF
--- a/src/lib/query.js
+++ b/src/lib/query.js
@@ -30,9 +30,18 @@ export const concatenation = (originalStr, params = {}) => {
       Object.keys(params[key]).map(k => {
         const value = params[key][k];
 
-        if (value) {
-          return Number.isNaN(value) ? `${k} = '${value}'` : `${k} = ${value}`;
+        if (Array.isArray(value) && !!value.length) {
+          // window.isNaN is needed here as Number.isNaN returns
+          // false in the case Number.isNaN('string'). please dont change.
+          const mappedValue = value.map(v => (
+            window.isNaN(v) ? `'${v}'` : v)) // eslint-disable-line
+          return `${k} IN (${mappedValue.join(', ')})`
         }
+
+        if (value) {
+          return window.isNaN(value) ? `${k} = '${value}'` : `${k} = ${value}`; // eslint-disable-line
+        }
+
         return null;
       })
     ).join(' AND ')}`;

--- a/src/services/carto-service.js
+++ b/src/services/carto-service.js
@@ -25,7 +25,10 @@ export const fetchTile = layerModel => {
   if (layerRequest && layerRequest instanceof Promise) layerRequest.cancel();
 
   const newLayerRequest = get(url).then(res => {
-    if (res.status > 400) throw new Error(res);
+    if (res.status > 400) {
+      console.error(res);
+      return false;
+    }
     return JSON.parse(res.response);
   });
 

--- a/test/specs/helpers.test.js
+++ b/test/specs/helpers.test.js
@@ -9,7 +9,10 @@ describe('# Cancellable request', () => {
 
     request
       .then((res) => {
-        if (res.status > 400) throw new Error(res);
+        if (res.status > 400) {
+          console.error(res);
+          return false;
+        }
         return JSON.parse(res.response);
       })
       .then((json) => {


### PR DESCRIPTION
Simple update to the sql query helper to address the following:

1. Fix a bug with `Number.isNaN()` which was returning false on strings causing single strings to miss the additional `''` around the string comparator. Now using `window.isNan()`.

2. Add a new case where an Array can be passed as the param value. In this case the `IN` operator is is substituted to allow simple `OR` comparison for single `{{param}}` comparisons.

3. Remove the `throw new Error()` issues causing apps to crash and white screen when adding less than desirable layers. You know the kind 👊 .

4. There was an error with sqlParams changing and not updating the layer. This has been fixed by doing correct comparisons in the updateLayer function.