### PR TITLE
Fix/remove refetching tiles on decode change

### DIFF
--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -18,11 +18,10 @@ class LayerManager {
     if (this.layers.length > 0) {
       this.layers.map((layerModel) => {
         const {
-          changedAttributes,
-          decodeParams
+          changedAttributes
         } = layerModel;
         const { sqlParams, params } = changedAttributes;
-        const hasChanged = (sqlParams || params) && isEmpty(decodeParams);
+        const hasChanged = sqlParams || params;
 
         // If layer exists let's update it
         if (layerModel.mapLayer && !hasChanged) {
@@ -130,15 +129,9 @@ class LayerManager {
       this.requestLayer(layerModel);
     }
 
-    if (!isEmpty(params) && isEmpty(layerModel.decodeParams)) this.plugin.setParams(layerModel);
-    if (!isEmpty(sqlParams) && isEmpty(layerModel.decodeParams)) {
-      this.plugin.setParams(layerModel); }
-    if (
-      (!isEmpty(params) && !isEmpty(layerModel.decodeParams)) ||
-      (!isEmpty(sqlParams) && !isEmpty(layerModel.decodeParams)) ||
-      !isEmpty(decodeParams)
-    ) {
-      this.plugin.setDecodeParams(layerModel); }
+    if (!isEmpty(params)) this.plugin.setParams(layerModel);
+    if (!isEmpty(sqlParams)) this.plugin.setParams(layerModel);
+    if (!isEmpty(decodeParams)) this.plugin.setDecodeParams(layerModel);
   }
 
   /**

--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -124,7 +124,7 @@ class LayerManager {
     if (typeof events !== 'undefined') {
       this.setEvents(layerModel);
     }
-    
+
     if (typeof layerConfig !== 'undefined') {
       this.plugin.remove(layerModel);
       this.requestLayer(layerModel);

--- a/src/plugins/plugin-leaflet/canvas-layer-leaflet.js
+++ b/src/plugins/plugin-leaflet/canvas-layer-leaflet.js
@@ -171,10 +171,7 @@ const CanvasLayer = L && L.GridLayer.extend({
       const { x, y, z } = this.tiles[k];
       const id = replace(params.url, { x, y, z, ...params, sqlParams });
 
-      return this.getTile({ x, y, z }).then((image) => {
-        this.cacheTile({ ...this.tiles[k], id, image, ...{ x, y, z } });
-        this.drawCanvas(id);
-      });
+      return this.drawCanvas(id);
     });
   }
 });

--- a/src/plugins/plugin-leaflet/index.js
+++ b/src/plugins/plugin-leaflet/index.js
@@ -166,7 +166,7 @@ class PluginLeaflet {
       decodeFunction
     } = layerModel;
 
-    mapLayer.reDraw({ params, sqlParams, decodeParams, decodeFunction });
+    mapLayer.reDraw({ decodeParams, decodeFunction, params, sqlParams });
 
     return this;
   }

--- a/src/plugins/plugin-leaflet/index.js
+++ b/src/plugins/plugin-leaflet/index.js
@@ -144,7 +144,6 @@ class PluginLeaflet {
         });
       } else {
         mapLayer.on(k, events[k]);
-        console.log(mapLayer);
       }
     });
 


### PR DESCRIPTION
When drawing the canvas layers with the decode functions, after the initial tile fetch and cache, we pass decode params to update and re draw the tiles. Currently we are also refetching the tiles also. This causes the layer to break after first load and initial draw.

This fixes that issue.