### PR TITLE
Fix: layerConfig reacts to changes removing the current layer

### DIFF
--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -20,8 +20,8 @@ class LayerManager {
         const {
           changedAttributes
         } = layerModel;
-        const { sqlParams, params } = changedAttributes;
-        const hasChanged = sqlParams || params;
+        const { sqlParams, params, layerConfig } = changedAttributes;
+        const hasChanged = sqlParams || params || layerConfig;
 
         // If layer exists let's update it
         if (layerModel.mapLayer && !hasChanged) {
@@ -124,11 +124,7 @@ class LayerManager {
       this.setEvents(layerModel);
     }
 
-    if (typeof layerConfig !== 'undefined') {
-      this.plugin.remove(layerModel);
-      this.requestLayer(layerModel);
-    }
-
+    if (!isEmpty(layerConfig)) this.plugin.setLayerConfig(layerModel);
     if (!isEmpty(params)) this.plugin.setParams(layerModel);
     if (!isEmpty(sqlParams)) this.plugin.setParams(layerModel);
     if (!isEmpty(decodeParams)) this.plugin.setDecodeParams(layerModel);

--- a/src/plugins/plugin-leaflet/index.js
+++ b/src/plugins/plugin-leaflet/index.js
@@ -157,6 +157,10 @@ class PluginLeaflet {
     this.remove(layerModel);
   }
 
+  setLayerConfig(layerModel) {
+    this.remove(layerModel);
+  }
+
   setDecodeParams(layerModel) {
     const {
       mapLayer,


### PR DESCRIPTION
This PR removes the current layer if the `layerConfig` has changed. It works similar to the params and sqlParams, it will remove the layer and ask for a new one