### PR TITLE
Fix/load x0 tiles

### DIFF
--- a/src/plugins/plugin-leaflet/canvas-layer-leaflet.js
+++ b/src/plugins/plugin-leaflet/canvas-layer-leaflet.js
@@ -100,13 +100,14 @@ const CanvasLayer = L && L.GridLayer.extend({
     },
     drawCanvas(id) {
       'use asm';
+
       if (!this.tiles[id]) {
         return;
       }
 
       const { tile, ctx, image, x, y, z } = this.tiles[id];
 
-      if (!tile || !ctx || !image || !x || !y || !z) {
+      if (!tile || !ctx || !image || typeof x === 'undefined' || typeof y === 'undefined' || typeof z === 'undefined') {
         delete this.tiles[id];
         return;
       }


### PR DESCRIPTION
We have a bug where as we are checking for `!x` when drawing a canvas layer, so skip anything that is `x === 0`. This fixes that and check instead for undefined.