### PR TITLE
Adds params parser to layer model

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
   },
   "dependencies": {
     "bluebird": "^3.5.2",
+    "d3-scale": "^2.1.2",
     "lodash": "^4.17.10",
+    "moment": "^2.22.2",
     "prop-types": "^15.6.2",
     "reselect": "^3.0.1",
     "supercluster": "^4.1.1",

--- a/src/canvas-decodes.js
+++ b/src/canvas-decodes.js
@@ -1,0 +1,493 @@
+import { scalePow } from 'd3-scale';
+
+import {
+  dateDiffInDays,
+  getYear,
+  getDayOfYear,
+  addToDate,
+  formatDate
+} from './utils/dates';
+
+// IMPORTANT NOTE: right now decodes are linked with dataste ids, which means
+// if the id of the dataset changes (even if it is the same spec)
+// it won't work. Would be a good practice move this functions to the API
+// at some point.
+
+const getExp = z => (z < 11 ? 0.3 + (z - 3) / 20 : 1);
+
+const getScale = z =>
+  scalePow()
+    .exponent(getExp(z))
+    .domain([0, 256])
+    .range([0, 256]);
+
+const padNumber = number => {
+  const s = `00${number}`;
+  return s.substr(s.length - 3);
+};
+
+const getDayRange = params => {
+  const { startDate, endDate, minDate, maxDate, weeks } = params || {};
+
+  const minDateTime = new Date(minDate);
+  const maxDateTime = new Date(maxDate);
+  const numberOfDays = dateDiffInDays(maxDateTime, minDateTime);
+
+  // timeline or hover effect active range
+  const startDateTime = new Date(startDate);
+  const endDateTime = new Date(endDate);
+  const activeStartDay =
+    numberOfDays - dateDiffInDays(maxDateTime, startDateTime);
+  const activeEndDay = numberOfDays - dateDiffInDays(maxDateTime, endDateTime);
+
+  // show specified weeks from end date
+  const rangeStartDate = weeks && numberOfDays - 7 * weeks;
+  // get start and end day
+  const startDay = activeStartDay || rangeStartDate || 0;
+  const endDay = activeEndDay || numberOfDays;
+
+  return {
+    startDay,
+    endDay,
+    numberOfDays
+  };
+};
+
+const decodes = {
+  treeCover: (data, w, h, z) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+    const myScale = getScale(z);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const intensity = imgData[pixelPos + 1];
+
+        imgData[pixelPos] = 151;
+        imgData[pixelPos + 1] = 189;
+        imgData[pixelPos + 2] = 61;
+        imgData[pixelPos + 3] =
+          z < 13 ? myScale(intensity) * 0.8 : intensity * 0.8;
+      }
+    }
+  },
+  treeCoverLoss: (data, w, h, z, params) => {
+    'use asm';
+
+    const components = 4;
+    const imgData = data;
+    const myScale = getScale(z);
+
+    const { startDate, endDate } = params;
+    const yearStart = getYear(startDate);
+    const yearEnd = getYear(endDate);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const yearLoss = 2000 + imgData[pixelPos + 2];
+        if (yearLoss >= yearStart && yearLoss <= yearEnd) {
+          const intensity = imgData[pixelPos];
+          const scaleIntensity = myScale(intensity);
+          imgData[pixelPos] = 220;
+          imgData[pixelPos + 1] = 72 - z + 102 - 3 * scaleIntensity / z;
+          imgData[pixelPos + 2] = 33 - z + 153 - intensity / z;
+          imgData[pixelPos + 3] = z < 13 ? scaleIntensity : intensity;
+        } else {
+          imgData[pixelPos + 3] = 0;
+        }
+      }
+    }
+  },
+  treeLossByDriver: (data, w, h, z, params) => {
+    'use asm';
+
+    const components = 4;
+    const imgData = data;
+    const myScale = getScale(z);
+
+    const { startDate, endDate } = params;
+    const yearStart = getYear(startDate);
+    const yearEnd = getYear(endDate);
+
+    const lossColors = {
+      0: [255, 255, 255],
+      1: [244, 29, 54],
+      2: [239, 211, 26],
+      3: [47, 191, 113],
+      4: [173, 54, 36],
+      5: [178, 53, 204]
+    };
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const yearLoss = 2000 + imgData[pixelPos + 2];
+
+        if (yearLoss >= yearStart && yearLoss < yearEnd) {
+          const lossCat = imgData[pixelPos + 1];
+          const rgb = lossColors[lossCat || 0];
+          const intensity = imgData[pixelPos];
+          const scale = myScale(intensity);
+          imgData[pixelPos] = rgb[0];
+          imgData[pixelPos + 1] = 72 - z + rgb[1] - 3 * scale / z;
+          imgData[pixelPos + 2] = 33 - z + rgb[2] - intensity / z;
+          imgData[pixelPos + 3] = z < 13 ? scale : intensity;
+        } else {
+          imgData[pixelPos + 3] = 0;
+        }
+      }
+    }
+  },
+  GLADs: (data, w, h, z, params) => {
+    'use asm';
+
+    // fixed variables
+    const imgData = data;
+    const { confirmedOnly } = params;
+
+    const { startDay, endDay, numberOfDays } = getDayRange(params) || {};
+
+    const confidenceValue = confirmedOnly ? 200 : 0;
+    const pixelComponents = 4; // RGBA
+    let pixelPos = 0;
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        pixelPos = (j * w + i) * pixelComponents;
+        // day 0 is 2015-01-01 until latest date from fetch
+        const day = imgData[pixelPos] * 255 + imgData[pixelPos + 1];
+        const confidence = data[pixelPos + 2];
+
+        if (
+          day > 0 &&
+          day >= startDay &&
+          day <= endDay &&
+          confidence >= confidenceValue
+        ) {
+          // get intensity
+          let intensity = (confidence % 100) * 50;
+          if (intensity > 255) {
+            intensity = 255;
+          }
+          if (day >= numberOfDays - 7 && day <= numberOfDays) {
+            imgData[pixelPos] = 219;
+            imgData[pixelPos + 1] = 168;
+            imgData[pixelPos + 2] = 0;
+            imgData[pixelPos + 3] = intensity;
+          } else {
+            imgData[pixelPos] = 220;
+            imgData[pixelPos + 1] = 102;
+            imgData[pixelPos + 2] = 153;
+            imgData[pixelPos + 3] = intensity;
+          }
+          continue; // eslint-disable-line
+        }
+
+        imgData[pixelPos + 3] = 0;
+      }
+    }
+  },
+  biomassLoss: (data, w, h, z, params) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+    const myScale = getScale(z);
+
+    const { startDate, endDate } = params;
+    const yearStart = getYear(startDate);
+    const yearEnd = getYear(endDate);
+
+    const buckets = [
+      255,
+      31,
+      38, // first bucket R G B
+      210,
+      31,
+      38,
+      210,
+      31,
+      38,
+      241,
+      152,
+      19,
+      255,
+      208,
+      11
+    ]; // last bucket
+    const countBuckets = buckets.length / 3; // 3: three bands
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        imgData[pixelPos + 3] = 0;
+
+        if (imgData[pixelPos] !== 0) {
+          // get values from data
+          const intensity = myScale(imgData[pixelPos + 1]);
+          // filter range from dashboard
+          if (intensity >= 0 && intensity <= 255) {
+            const yearLoss = 2000 + imgData[pixelPos];
+            if (yearLoss >= yearStart && yearLoss < yearEnd) {
+              const bucket = Math.floor(countBuckets * intensity / 256) * 3;
+              imgData[pixelPos] = buckets[bucket]; // R 0-255
+              imgData[pixelPos + 1] = buckets[bucket + 1]; // G 0-255
+              imgData[pixelPos + 2] = buckets[bucket + 2]; // B 0-255
+              imgData[pixelPos + 3] = intensity; // alpha channel 0-255
+            }
+          }
+        }
+        continue; // eslint-disable-line
+      }
+    }
+  },
+  woodyBiomass: (data, w, h) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const intensity = imgData[pixelPos + 2];
+        imgData[pixelPos] = 255 - intensity;
+        imgData[pixelPos + 1] = 128;
+        imgData[pixelPos + 2] = 0;
+        imgData[pixelPos + 3] = 0;
+        if (intensity > 0) {
+          imgData[pixelPos + 3] = intensity;
+        }
+      }
+
+      continue; // eslint-disable-line
+    }
+  },
+  forma: (data, w, h, z, params) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+
+    const { startDay, endDay } = getDayRange(params) || {};
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const g = imgData[pixelPos + 1];
+        const b = imgData[pixelPos + 2];
+        const day = 255 * g + b;
+
+        if (day >= startDay && day <= endDay) {
+          const band3_str = padNumber(imgData[pixelPos].toString());
+          const intensity_raw = parseInt(band3_str.slice(1, 3), 10);
+          // Scale the intensity to make it visible
+          let intensity = intensity_raw * 55;
+          // Set intensity to 255 if it's > than that value
+          if (intensity > 255) {
+            intensity = 255;
+          }
+
+          imgData[pixelPos] = 220;
+          imgData[pixelPos + 1] = 102;
+          imgData[pixelPos + 2] = 153;
+          imgData[pixelPos + 3] = intensity;
+
+          continue; // eslint-disable-line
+        }
+        imgData[pixelPos + 3] = 0;
+      }
+    }
+  },
+  terrai: (data, w, h, z, params) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+
+    const { startDate, endDate, minDate, maxDate } = params || {};
+
+    const startYear = getYear(startDate);
+    const minYear = getYear(minDate);
+    const maxYear = getYear(maxDate);
+    const maxYearDay = getDayOfYear(maxDate);
+    const endYearDay = getDayOfYear(endDate);
+    const recentStartDate = formatDate(addToDate(maxDate, -1, 'months'));
+    const recentStartYear = getYear(recentStartDate);
+    const recentStartDay = getDayOfYear(recentStartDate);
+
+    const startDay =
+      (startYear - minYear) * 23 + Math.floor(endYearDay / 16 + 1);
+
+    const endDay =
+      (getYear(endDate) - minYear) * 23 + Math.floor(endYearDay / 16 + 1);
+
+    const recentStartRange =
+      (recentStartYear - minYear) * 23 + Math.floor(recentStartDay / 16 + 1);
+
+    const recentEndRange =
+      (maxYear - minYear) * 23 + Math.floor(maxYearDay / 16 + 1);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+
+        const r = imgData[pixelPos];
+        const g = imgData[pixelPos + 1];
+        const day = r + g;
+
+        if (day >= startDay && day <= endDay) {
+          const b = imgData[pixelPos + 2];
+          const intensity = Math.min(b * 4, 255);
+          if (day >= recentStartRange && day <= recentEndRange) {
+            imgData[pixelPos] = 219;
+            imgData[pixelPos + 1] = 168;
+            imgData[pixelPos + 2] = 0;
+            imgData[pixelPos + 3] = intensity;
+          } else {
+            imgData[pixelPos] = 220;
+            imgData[pixelPos + 1] = 102;
+            imgData[pixelPos + 2] = 153;
+            imgData[pixelPos + 3] = intensity;
+          }
+
+          continue; // eslint-disable-line
+        }
+
+        imgData[pixelPos + 3] = 0;
+      }
+    }
+  },
+  braLandCover: (data, w, h, z) => {
+    'use asm';
+
+    const imgData = data;
+    const components = 4;
+    const myScale = getScale(z);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        // maps over square
+        const pixelPos = (j * w + i) * components;
+        const intensity = imgData[pixelPos + 1];
+
+        imgData[pixelPos + 3] =
+          z < 13 ? myScale(intensity) * 256 : intensity * 256;
+
+        // Forest Formations
+        if (imgData[pixelPos] === 3) {
+          imgData[pixelPos] = 0;
+          imgData[pixelPos + 1] = 100;
+          imgData[pixelPos + 2] = 0;
+        } else if (imgData[pixelPos] === 4) {
+          // Savannah Formations
+          imgData[pixelPos] = 141;
+          imgData[pixelPos + 1] = 144;
+          imgData[pixelPos + 2] = 35;
+        } else if (imgData[pixelPos] === 5) {
+          // Mangroves
+          imgData[pixelPos] = 138;
+          imgData[pixelPos + 1] = 168;
+          imgData[pixelPos + 2] = 29;
+        } else if (imgData[pixelPos] === 9) {
+          // Planted Forest
+          imgData[pixelPos] = 232;
+          imgData[pixelPos + 1] = 163;
+          imgData[pixelPos + 2] = 229;
+        } else if (imgData[pixelPos] === 11) {
+          // Non-forest Wetlands
+          imgData[pixelPos] = 39;
+          imgData[pixelPos + 1] = 137;
+          imgData[pixelPos + 2] = 212;
+        } else if (imgData[pixelPos] === 12) {
+          // Grassland
+          imgData[pixelPos] = 204;
+          imgData[pixelPos + 1] = 219;
+          imgData[pixelPos + 2] = 152;
+        } else if (imgData[pixelPos] === 13) {
+          // Other Non-forest Vegetation
+          imgData[pixelPos] = 138;
+          imgData[pixelPos + 1] = 184;
+          imgData[pixelPos + 2] = 75;
+        } else if (imgData[pixelPos] === 15) {
+          // Pasture
+          imgData[pixelPos] = 255;
+          imgData[pixelPos + 1] = 184;
+          imgData[pixelPos + 2] = 126;
+        } else if (imgData[pixelPos] === 18) {
+          // Agriculture
+          imgData[pixelPos] = 210;
+          imgData[pixelPos + 1] = 169;
+          imgData[pixelPos + 2] = 101;
+        } else if (imgData[pixelPos] === 21) {
+          // Pasture or Agriculture
+          imgData[pixelPos] = 232;
+          imgData[pixelPos + 1] = 176;
+          imgData[pixelPos + 2] = 113;
+        } else if (imgData[pixelPos] === 23) {
+          // Beaches and Dunes
+          imgData[pixelPos] = 221;
+          imgData[pixelPos + 1] = 126;
+          imgData[pixelPos + 2] = 107;
+        } else if (imgData[pixelPos] === 24) {
+          // Urban Infrastructure
+          imgData[pixelPos] = 233;
+          imgData[pixelPos + 1] = 70;
+          imgData[pixelPos + 2] = 43;
+        } else if (imgData[pixelPos] === 25) {
+          // Other Non-vegetated Area
+          imgData[pixelPos] = 255;
+          imgData[pixelPos + 1] = 153;
+          imgData[pixelPos + 2] = 255;
+        } else if (imgData[pixelPos] === 26) {
+          // Water Bodies
+          imgData[pixelPos] = 163;
+          imgData[pixelPos + 1] = 220;
+          imgData[pixelPos + 2] = 254;
+        } else if (imgData[pixelPos] === 27) {
+          // Unobserved
+          imgData[pixelPos] = 235;
+          imgData[pixelPos + 1] = 236;
+          imgData[pixelPos + 2] = 236;
+          imgData[pixelPos + 3] = 0;
+        } else if (
+          imgData[pixelPos] === 1 ||
+          imgData[pixelPos] === 2 ||
+          imgData[pixelPos] === 10 ||
+          imgData[pixelPos] === 14
+        ) {
+          // Unknown / No data
+          imgData[pixelPos] = 256;
+          imgData[pixelPos + 1] = 256;
+          imgData[pixelPos + 2] = 256;
+          imgData[pixelPos + 3] = 0;
+        } else {
+          imgData[pixelPos] = 256;
+          imgData[pixelPos + 1] = 256;
+          imgData[pixelPos + 2] = 256;
+          imgData[pixelPos + 3] = 0;
+        }
+      }
+    }
+  }
+};
+
+export default {
+  // GFW
+  '78747ea1-34a9-4aa7-b099-bdb8948200f4': decodes.treeCover,
+  'c05c32fd-289c-4b20-8d73-dc2458234e04': decodes.treeCover,
+  'c3075c5a-5567-4b09-bc0d-96ed1673f8b6': decodes.treeCoverLoss,
+  'dcb082a9-6fd7-4564-9110-ddf5d3d6681e': decodes.treeLossByDriver,
+  'dd5df87f-39c2-4aeb-a462-3ef969b20b66': decodes.GLADs,
+  'b32a2f15-25e8-4ecc-98e0-68782ab1c0fe': decodes.biomassLoss,
+  'f10bded4-94e2-40b6-8602-ae5bdfc07c08': decodes.woodyBiomass,
+  '66203fea-2e58-4a55-b222-1dae075cf95d': decodes.forma,
+  '790b46ce-715a-4173-8f2c-53980073acb6': decodes.terrai,
+  '220080ec-1641-489c-96c4-4885ed618bf3': decodes.braLandCover,
+  // RW
+  '214e1278-0ca5-4bbb-aff3-1f7ec4bd0cd1': decodes.treeCoverLoss
+};

--- a/src/layer-model.js
+++ b/src/layer-model.js
@@ -1,12 +1,28 @@
 import isEqual from 'lodash/isEqual';
 
+// decodes
+import canvasDecodes from './canvas-decodes';
+
 class LayerModel {
   opacity = 1;
 
   visibility = true;
 
   constructor(layerSpec = {}) {
-    Object.assign(this, layerSpec, { changedAttributes: {} });
+    // parse params before setting model's properties
+    Object.assign(this, {
+      ...layerSpec,
+      ...{
+        ...LayerModel.parse(layerSpec),
+        // compatibility
+        ...layerSpec.params && { params: layerSpec.params },
+        ...layerSpec.sqlParams && { sqlParams: layerSpec.sqlParams },
+        ...layerSpec.decodeParams && { decodeParams: layerSpec.decodeParams },
+        // adds decodeFunction if the layerSpec contains decode_config params (it is a canvas layer)
+        ...Object.prototype.hasOwnProperty.call(layerSpec.layerConfig, 'decode_config') &&
+          { decodeFunction: canvasDecodes[layerSpec.id] }
+      }
+    }, { changedAttributes: {} });
   }
 
   get(key) {
@@ -20,7 +36,9 @@ class LayerModel {
 
   update(layerSpec) {
     const prevData = { ...this };
-    const nextData = { ...layerSpec };
+    const nextData = {
+      ...layerSpec
+    };
 
     // reseting changedAttributes for every update
     this.set('changedAttributes', {});
@@ -31,6 +49,42 @@ class LayerModel {
         this.set(k, nextData[k]);
       }
     });
+  }
+
+  static parse(layerSpec = {}) {
+    const {
+      params_config: paramsConfig,
+      sqlParams_config: sqlParamsConfig,
+      decode_config: decodeConfig,
+      body
+    } = layerSpec.layerConfig;
+    const { url } = body;
+    let params = {};
+    const sqlParams = {};
+    const decodeParams = {};
+
+    (paramsConfig || []).forEach(_param => {
+      if (_param.key && _param.default) params[_param.key] = _param.default;
+    });
+
+    params = {
+      ...params,
+      url
+    };
+
+    (sqlParamsConfig || []).forEach(_param => {
+      if (_param.key && _param.default) sqlParams[_param.key] = _param.default;
+    });
+
+    (decodeConfig || []).forEach(_param => {
+      if (_param.key && _param.default) decodeParams[_param.key] = _param.default;
+    });
+
+    return {
+      params,
+      sqlParams,
+      decodeParams
+    };
   }
 }
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,0 +1,132 @@
+import moment from 'moment';
+import find from 'lodash/find';
+import compact from 'lodash/compact';
+
+const AVAILABLE_DATE_RANGES = [
+  {
+    start: moment()
+      .subtract(7, 'days')
+      .utc(),
+    end: moment().utc(),
+    label: 'past week',
+    duration: 24 * 7
+  },
+  {
+    start: moment()
+      .subtract(3, 'days')
+      .utc(),
+    end: moment().utc(),
+    label: 'past 72 hours',
+    duration: 72
+  },
+  {
+    start: moment()
+      .subtract(2, 'days')
+      .utc(),
+    end: moment().utc(),
+    label: 'past 48 hours',
+    duration: 48
+  },
+  {
+    start: moment()
+      .subtract(1, 'days')
+      .utc(),
+    end: moment().utc(),
+    label: 'past 24 hours',
+    duration: 24
+  }
+];
+
+export function getRangeForDates(dates, range) {
+  const duration = moment(dates[1]).diff(moment(dates[0]), 'hours');
+  const dateRange = find(range || AVAILABLE_DATE_RANGES, duration);
+
+  return dateRange ? [dateRange.start, dateRange.end] : [dates[0], dates[1]];
+}
+
+export const addToDate = (date, count, interval = 'days') => {
+  const result = new Date(date);
+  if (interval === 'years') {
+    result.setFullYear(result.getFullYear() + count);
+  } else if (interval === 'months') {
+    result.setMonth(result.getMonth() + count);
+  } else if (interval === 'days') {
+    result.setDate(result.getDate() + count);
+  }
+  return result;
+};
+
+export const formatDate = (date, format = 'YYYY-MM-DD') => {
+  const d = new Date(date);
+  let month = null;
+  let day = null;
+  const year = d.getFullYear();
+
+  if (format.includes('MM')) {
+    month = (d.getMonth() + 1).toString();
+    if (month.length < 2) month = `0${month}`;
+  }
+
+  if (format.includes('DD')) {
+    day = d.getDate().toString();
+    if (day.length < 2) day = `0${day}`;
+  }
+
+  return compact([year, month, day]).join('-');
+};
+
+export const getYear = date => new Date(date).getUTCFullYear();
+
+export const getDayOfYear = date => new Date(date).getDate();
+
+export const formatDatePretty = (date, dateFormat = 'YYYY-MM-DD') => {
+  const d = new Date(date);
+  const hasDays = dateFormat.includes('DD');
+  const hasMonths = dateFormat.includes('MM');
+  const months = [
+    'JAN',
+    'FEB',
+    'MAR',
+    'APR',
+    'MAY',
+    'JUN',
+    'JUL',
+    'AUG',
+    'SEPT',
+    'OCT',
+    'NOV',
+    'DEC'
+  ];
+  let day = d.getDate().toString();
+  const month = d.getMonth();
+  const year = d.getFullYear();
+
+  if (day.length < 2) day = `0${day}`;
+
+  return `${hasDays ? `${day} ` : ''}${hasMonths ? `${months[month]} ` : ''}${
+    year
+  }`;
+};
+
+const _MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+// a and b are javascript Date objects
+export const dateDiffInDays = (startDate, endDate) => {
+  const a = new Date(endDate);
+  const b = new Date(startDate);
+  // Discard the time and time-zone information.
+  const utc1 = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());
+  const utc2 = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate());
+
+  return Math.floor((utc2 - utc1) / _MS_PER_DAY);
+};
+
+export default {
+  getRangeForDates,
+  addToDate,
+  formatDate,
+  getYear,
+  getDayOfYear,
+  formatDatePretty,
+  dateDiffInDays
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,6 +1258,57 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
+  integrity sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==
+
+d3-format@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.2.tgz#6a96b5e31bcb98122a30863f7d92365c00603562"
+  integrity sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==
+
+d3-interpolate@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
+  integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==
+  dependencies:
+    d3-color "1"
+
+d3-scale@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.2.tgz#4e932b7b60182aee9073ede8764c98423e5f9a94"
+  integrity sha512-bESpd64ylaKzCDzvULcmHKZTlzA/6DGSVwx7QSDj/EnX9cpSevsdiwdHFYI9ouo9tNBbV3v5xztHS2uFeOzh8Q==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-time-format@2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.3.tgz#ae06f8e0126a9d60d6364eac5b1533ae1bac826b"
+  integrity sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.10.tgz#8259dd71288d72eeacfd8de281c4bf5c7393053c"
+  integrity sha512-hF+NTLCaJHF/JqHN5hE8HVGAXPStEq6/omumPE/SxyHVrR7/qQxusFDo0t0c/44+sCGHthC7yNGFZIEgju0P8g==
+
 damerau-levenshtein@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
@@ -2559,6 +2610,11 @@ mocha@^5.0.4:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "5.4.0"
+
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Problem**: right now, apps are in charge of parsing layer's params before giving them to the layer manager. This becomes an issue when you export a layer from one app to another because you need to add that parse (coming from the other app) to your app (which has no sense, in my opinion).

**Solution**: moving parse to layer manager, to the layer model concretely. Based on a common set of keys we use cross our apps (like params_config, sqlParams_config, ...) we can just update the layer specs and let the layer manager create the params object required for parametrization.

The only **requirements** right now are the format, any config needs an object like 
```
{ key: 'startDate', default: '09-11-2018' }
```
Any other key inside the object is ignored at this moment (we can specify some use cases if needed, like `required`)

Would be nice some feedback, and let's see if we can get rid of all parsers we have in the apps :)

**Update**: the layer model will parse the params _on the creation_ (constructor), any update of it will be up to the application.

Also, we have imported canvas decodes from GFW as we'll need them for rendering any canvas layer. Inside the file there are some notes about it and what would be amazing to do with them in the future.

More: I am afraid I am adding `moment` to the library, not a huge fan but this is how it was implemented in GFW and I just copied from there. We can change it for a lighter library to manipulate dates.