### PR TITLE
Fix: layers not rendered on mount

### DIFF
--- a/src/react/layer-manager.js
+++ b/src/react/layer-manager.js
@@ -32,6 +32,15 @@ class LayerManager extends PureComponent {
     this.layerManager = new Manager(map, plugin);
   }
 
+  componentDidMount() {
+    const { onLayerLoading } = this.props;
+    if (this.layerManager.layers && this.layerManager.layers.length) {
+      onLayerLoading(true);
+      this.layerManager.renderLayers().then(() => onLayerLoading(false));
+    }
+  }
+
+
   componentDidUpdate() {
     const { onLayerLoading } = this.props;
     if (this.layerManager.layers && this.layerManager.layers.length) {

--- a/src/react/layer.js
+++ b/src/react/layer.js
@@ -25,7 +25,7 @@ class Layer extends PureComponent {
 
   addSpecToLayerManager() {
     const { layerManager, ...layerSpec } = this.props;
-    layerManager.add([ layerSpec ], {});
+    layerManager.add([layerSpec], {});
   }
 
   render() {


### PR DESCRIPTION
This PR fixes a bug, where layers where only being rendered on `componentDidUpdate` so if layers didn't change after initial render they wouldn't show up. 