### PR TITLE
Fix/cancel tokens inside services

### DIFF
--- a/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
+++ b/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
@@ -81,7 +81,7 @@ const LeafletLayer = (layerModel) => {
           `(${layerConfigParsed.body.style})`,
         );
       }
-      layer = new ClusterLayer({ ...layerModel });
+      layer = new ClusterLayer(layerModel);
       break;
     default:
       layer = L[layerConfigParsed.type](

--- a/src/services/cluster-service.js
+++ b/src/services/cluster-service.js
@@ -2,16 +2,17 @@ import { CancelToken } from 'axios';
 import { get } from 'lib/request';
 
 export const fetchData = (layerModel) => {
-  const source = CancelToken.source();
-  const { layerConfig } = layerModel;
-  const { layerRequest } = layerModel;
+  const { layerConfig, layerRequest } = layerModel;
   const { url } = layerConfig.body;
 
-  if (layerRequest && layerRequest instanceof Promise) {
-    source.cancel('Operation canceled by the user.');
+  if (layerRequest) {
+    layerRequest.cancel('Operation canceled by the user.');
   }
 
-  const newLayerRequest = get(url, { cancelToken: source.token }).then((res) => {
+  const layerRequestSource = CancelToken.source();
+  layerModel.set('layerRequest', layerRequestSource);
+
+  const newLayerRequest = get(url, { cancelToken: layerRequestSource.token }).then((res) => {
     if (res.status > 400) {
       console.error(res);
       return false;


### PR DESCRIPTION
Due to the cancel tokens being invoked before canceling concurrent fetches, we were preventing any fetches after the first from being triggered. Resulting in a no additional fetches being made and prevent layer manager from showing updates to layer params.