### PR TITLE
fix: remove debounce from leaflet plugin setEvents

### DIFF
--- a/src/plugins/plugin-leaflet/index.js
+++ b/src/plugins/plugin-leaflet/index.js
@@ -1,5 +1,3 @@
-import debounce from 'lodash-es/debounce';
-
 import cartoLayer from './carto-layer-leaflet';
 import esriLayer from './esri-layer-leaflet';
 import geeLayer from './gee-layer-leaflet';

--- a/src/plugins/plugin-leaflet/index.js
+++ b/src/plugins/plugin-leaflet/index.js
@@ -124,42 +124,38 @@ class PluginLeaflet {
    * A namespace to set DOM events
    * @param {Object} layerModel
   */
-  setEvents = debounce(
-    (layerModel) => {
-      const { mapLayer, events } = layerModel;
-      if (layerModel.layerConfig.type !== 'cluster') {
-        // Remove current events
-        if (this.events[layerModel.id]) {
-          Object.keys(this.events[layerModel.id]).forEach((k) => {
-            if (mapLayer.group) {
-              mapLayer.eachLayer((l) => {
-                l.off(k);
-              });
-            } else {
-              mapLayer.off(k);
-            }
-          });
-        }
-
-        // Add new events
-        Object.keys(events).forEach((k) => {
+  setEvents = (layerModel) => {
+    const { mapLayer, events } = layerModel;
+    if (layerModel.layerConfig.type !== 'cluster') {
+      // Remove current events
+      if (this.events[layerModel.id]) {
+        Object.keys(this.events[layerModel.id]).forEach((k) => {
           if (mapLayer.group) {
             mapLayer.eachLayer((l) => {
-              l.on(k, events[k]);
+              l.off(k);
             });
           } else {
-            mapLayer.on(k, events[k]);
+            mapLayer.off(k);
           }
         });
-        // Set this.events equal to current ones
-        this.events[layerModel.id] = events;
       }
 
-      return this;
-    },
-    200,
-    { leading: true }
-  );
+      // Add new events
+      Object.keys(events).forEach((k) => {
+        if (mapLayer.group) {
+          mapLayer.eachLayer((l) => {
+            l.on(k, events[k]);
+          });
+        } else {
+          mapLayer.on(k, events[k]);
+        }
+      });
+      // Set this.events equal to current ones
+      this.events[layerModel.id] = events;
+    }
+
+    return this;
+  };
 
   setParams(layerModel) {
     this.remove(layerModel);


### PR DESCRIPTION
This PR fixes #43 caused by `lodash.debounce`. This approach doesn't work properly when setting multiple layers events sequentially.