### PR TITLE
Feature/add leaflet vector definition for tile layers

### DIFF
--- a/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
+++ b/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
@@ -83,6 +83,19 @@ const LeafletLayer = (layerModel) => {
       }
       layer = new ClusterLayer(layerModel);
       break;
+    case 'vector':
+      if (
+        JSON.stringify(layerConfigParsed.body).indexOf('style: "function') >= 0
+      ) {
+        layerConfigParsed.body.style = eval2(
+          `(${layerConfigParsed.body.style})`,
+        );
+      }
+      layer = L.vectorGrid.protobuf(layerConfigParsed.url || layerConfigParsed.body.url, {
+        ...layerConfigParsed.body,
+        interactive: interactivity
+      });
+      break;
     default:
       layer = L[layerConfigParsed.type](
         layerConfigParsed.body,

--- a/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
+++ b/src/plugins/plugin-leaflet/leaflet-layer-leaflet.js
@@ -91,7 +91,7 @@ const LeafletLayer = (layerModel) => {
           `(${layerConfigParsed.body.style})`,
         );
       }
-      layer = L.vectorGrid.protobuf(layerConfigParsed.url || layerConfigParsed.body.url, {
+      layer = L.vectorGrid && L.vectorGrid.protobuf(layerConfigParsed.url || layerConfigParsed.body.url, {
         ...layerConfigParsed.body,
         interactive: interactivity
       });


### PR DESCRIPTION
Fairly simple in concept: allow rendering of vector tiles on within the leaflet plugin. This is achieved by adding the following plugin to your project (docs here: http://leaflet.github.io/Leaflet.VectorGrid/vectorgrid-api-docs.html):

`<script src="https://unpkg.com/leaflet.vectorgrid@latest/dist/Leaflet.VectorGrid.bundled.js"></script>`

### Config

and passing in a layer with the following layerConfig:

```
{
    service: 'leaflet',
    type: 'vector',
    body: {
        format: "leaflet",
        subdomains: "abcd",
        maxzoom: 12,
        minzoom: 3,
        options: {
            useCors: true
        },
        url: "coolURrl",
        vectorTileLayerStyles: {
            some_vector_key: {
                 fillColor: 'red'
            }
        }
   }
}
```

### Interactivity 

Interactivity is also possible by following the same schema as carto interactive layers, with the difference that the event will return `layer.properties` instead of `data` with the target info.
