### PR TITLE
documents react version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ or using git:
 
 `npm install vizzuality/layer-manager`
 
+## ❗ Requirements
+`layer-manager` requires `react@16.3.2` or higher to work.
+
 ## How to use
 
 ```js
@@ -128,3 +131,4 @@ this.map = L.map('c-map', mapOptions);
 	))}
 </LayerManager>;
 ```
+

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "wri-json-api-serializer": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "wri-json-api-serializer": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.3.2"
   }
 }


### PR DESCRIPTION
Documents the need for a minimum version of `react`.

Also, removes the possibility of working with `react@15` in `package.json` as it needs, at least, `react@16` to work.