### PR TITLE
Feature/ consolidate provider

### DIFF
--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -158,8 +158,8 @@ class LayerManager {
   }
 
   requestLayer(layerModel) {
-    const { provider } = layerModel;
-    const method = this.plugin.getLayerByProvider(provider, layerModel);
+    const { layerType, provider } = layerModel;
+    const method = this.plugin.getLayerByType(layerType) || this.plugin.getLayerByProvider(provider, layerModel);
 
     if (!method) {
       this.promises[layerModel.id] = Promise.reject(new Error(`${provider} provider is not yet supported.`));

--- a/src/plugins/plugin-mapbox-gl/index.js
+++ b/src/plugins/plugin-mapbox-gl/index.js
@@ -18,13 +18,19 @@ class PluginMapboxGL {
     });
   }
 
-  method = {
+  provider = {
     leaflet: rasterLayer,
     gee: rasterLayer,
     cartodb: vectorLayer,
     mapbox: vectorLayer,
     geojson: geoJsonLayer
   };
+
+  type = {
+    raster: rasterLayer,
+    vector: vectorLayer,
+    geojson: geoJsonLayer
+  }
 
   /**
    * Add a layer
@@ -72,15 +78,23 @@ class PluginMapboxGL {
   }
 
   /**
-   * Get provider method
+   * Get method by provider
    * @param {String} provider
    */
   getLayerByProvider(provider, layerModel) {
     // required to maintain current layerSpec without creating a breaking change
     if (provider === 'leaflet' && layerModel.layerConfig.type === 'cluster') {
-      return this.method.geojson;
+      return this.provider.geojson;
     }
-    return this.method[provider];
+    return this.provider[provider];
+  }
+
+  /**
+   * Get method by type
+   * @param {String} type
+   */
+  getLayerByType(type) {
+    return this.type[type];
   }
 
   /**


### PR DESCRIPTION
Adds a new method to the layer manager request layer to allow the use of `layerType` prop from the layer config to choose a layer type.

` layerType = 'vector | geojson | raster '`

It also maintains the old method for accessing method using provider to prevent braking changes.