### PR TITLE
Feat: more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+  node_js:
+    - 10
+  cache: yarn
+  install:
+    - yarn install
+  script:
+    - yarn test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Vizzuality/layer-manager.svg?branch=develop)](https://travis-ci.org/Vizzuality/layer-manager)
+
 # Layer Manager
 
 A library to manage the addition, and removal of layers in Leaflet and Cesium maps (Google coming soon). Furthermore it provides methods to set opacity, visibility, events and more.
@@ -65,7 +67,7 @@ layerManager.add([
           ]
         }
       ],
-      params_config: [],	
+      params_config: [],
     },
   }
 ]);
@@ -95,7 +97,7 @@ layerManager.remove(['layerID']);
 ## Plugins
 The plugin is the way of abstract the layer managment from the implementation of the layer in the different type of maps that we will be using.
 
-There are some predefined plugins (LeafletPlugin, CesiumPlugin, MapboxPlugin) and there will be more! 
+There are some predefined plugins (LeafletPlugin, CesiumPlugin, MapboxPlugin) and there will be more!
 
 When you create an instance of the plugin you will receive the `map instance` so you can acces to it in all the methods below. You should also define all the providers and the functions that you are going to use to get the layer in an attribute called `methods`
 
@@ -287,7 +289,7 @@ const activeLayers = [
           ]
         }
       ],
-      params_config: [],	
+      params_config: [],
     },
   }
 ];

--- a/src/__tests__/layer-manager.js
+++ b/src/__tests__/layer-manager.js
@@ -1,0 +1,194 @@
+import LayerManger from 'index';
+import LayerModel from 'layer-model';
+
+function TestPlugin() {}
+TestPlugin.prototype.setLayerConfig = () => {};
+TestPlugin.prototype.setParams = () => {};
+TestPlugin.prototype.setSQLParams = () => {};
+TestPlugin.prototype.add = jest.fn();
+TestPlugin.prototype.remove = jest.fn();
+TestPlugin.prototype.setVisibility = jest.fn();
+TestPlugin.prototype.setOpacity = jest.fn();
+TestPlugin.prototype.setZIndex = jest.fn();
+TestPlugin.prototype.setDecodeParams = jest.fn();
+TestPlugin.prototype.getLayerByType = jest.fn().mockImplementation(type => {
+  if (type !== 'success') {
+    return () => ({
+      then: () => {}
+    });
+  }
+  const mapLayer = { id: 'YET_ANOTHER_MAP_LAYER' };
+  return () => Promise.resolve(mapLayer);
+});
+
+describe('Core layer manager', () => {
+  const MAP_INSTANCE = {};
+  const layerManager = new LayerManger(MAP_INSTANCE, TestPlugin);
+  layerManager.requestCancel = jest.fn();
+
+  beforeEach(() => {
+    TestPlugin.prototype.add.mockClear();
+    TestPlugin.prototype.remove.mockClear();
+    TestPlugin.prototype.setVisibility.mockClear();
+    TestPlugin.prototype.setOpacity.mockClear();
+    TestPlugin.prototype.setZIndex.mockClear();
+    TestPlugin.prototype.setDecodeParams.mockClear();
+    TestPlugin.prototype.getLayerByType.mockClear();
+    layerManager.requestCancel.mockClear();
+  });
+
+  it('adds layers to the map with default options', () => {
+    const layer = { id: 'layer_0' };
+
+    const layers = layerManager.add(layer);
+
+    expect(layers).toBe(layerManager.layers);
+    expect(layers.length).toBe(1);
+    expect(layers[0]).toBeInstanceOf(LayerModel);
+    expect(layers[0]).toEqual({
+      zIndex: 0,
+      opacity: 1,
+      id: layer.id,
+      visibility: true,
+      interactivity: null,
+      changedAttributes: {}
+    });
+  });
+
+  it('adds a layer with custom options', () => {
+    const customOptions = {
+      opacity: 0.5,
+      visibility: false,
+      zIndex: 22,
+      interactivity: true,
+      extra: 'wait what?' // is this expected behaviour?
+    };
+    const layer = { id: 'layer_1' };
+    layerManager.add(layer, customOptions);
+
+    expect(layerManager.layers[1]).toEqual({
+      ...customOptions,
+      id: layer.id,
+      changedAttributes: {}
+    });
+  });
+
+  it('returns new reference to layers using getLayers', () => {
+    const newLayers = [...layerManager.layers];
+    layerManager.layers = newLayers;
+    expect(layerManager.getLayers()).toBe(newLayers);
+  });
+
+  it('removes a layer', () => {
+    expect(layerManager.layers.length).toBe(2);
+    layerManager.remove('layer_0');
+    expect(layerManager.requestCancel).toHaveBeenCalled();
+    expect(TestPlugin.prototype.remove).toHaveBeenCalled();
+    expect(layerManager.layers.length).toBe(1);
+    expect(layerManager.layers[0].id).toMatch('layer_1');
+  });
+
+  it('sets layer opacity using plugin', () => {
+    const [layer] = layerManager.layers;
+    layerManager.setOpacity('layer_1', 0.8);
+    expect(TestPlugin.prototype.setOpacity).toHaveBeenCalledWith(layer, 0.8);
+  });
+
+  it('sets layer visibility using plugin', () => {
+    const [layer] = layerManager.layers;
+    layerManager.setVisibility('layer_1', true);
+    expect(TestPlugin.prototype.setVisibility).toHaveBeenCalledWith(layer, true);
+  });
+
+  it('sets layer z-index using plugin', () => {
+    const [layer] = layerManager.layers;
+    layerManager.setZIndex('layer_1', 11);
+    expect(TestPlugin.prototype.setZIndex).toHaveBeenCalledWith(layer, 11);
+  });
+
+  it('ignores updates on missing layerModels and layerModels without mapLayer', () => {
+    const changedProps = {
+      opacity: 1,
+      visibility: true,
+      zIndex: 0,
+      decodeParams: { stuff: [] }
+    };
+
+    layerManager.update('layer_0', changedProps);
+    layerManager.update('layer_1', changedProps);
+    expect(TestPlugin.prototype.setZIndex).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setOpacity).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setVisibility).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setDecodeParams).not.toHaveBeenCalled();
+  });
+
+  it('updates the layer and tracks changes in changedAttributes', () => {
+    const changedProps = {
+      opacity: 1,
+      visibility: true,
+      zIndex: 0
+    };
+
+    const originalLayer = { ...layerManager.layers[0] };
+    // we need a mapLayer in able to update a layer
+    const mapLayer = { id: 'A_MAP_LAYER' };
+    layerManager.layers[0].mapLayer = mapLayer;
+    layerManager.update('layer_1', changedProps);
+
+    expect(TestPlugin.prototype.setZIndex).toHaveBeenCalled();
+    expect(TestPlugin.prototype.setOpacity).toHaveBeenCalled();
+
+    // This seems to be a bug, it's not consistent.
+    expect(TestPlugin.prototype.setVisibility).toHaveBeenCalled();
+    expect(TestPlugin.prototype.setDecodeParams).not.toHaveBeenCalled();
+
+    expect(layerManager.layers[0]).toEqual({
+      ...originalLayer,
+      ...changedProps,
+      mapLayer,
+      // does it makes sense to save the data? Perhaps only the keys are needed?
+      changedAttributes: changedProps
+    });
+  });
+
+  it('updates only the decodeParams', () => {
+    const originalLayer = { ...layerManager.layers[0] };
+    const changedProps = {
+      decodeParams: { key: 'someParams' }
+    };
+    layerManager.update('layer_1', changedProps);
+
+    expect(TestPlugin.prototype.setZIndex).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setOpacity).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setVisibility).not.toHaveBeenCalled();
+    expect(TestPlugin.prototype.setDecodeParams).toHaveBeenCalled();
+
+    expect(layerManager.layers[0]).toEqual({
+      ...originalLayer,
+      ...changedProps,
+      // does it makes sense to save the data? Perhaps only the keys are needed?
+      changedAttributes: changedProps
+    });
+  });
+
+  it('successfully resolves request with a mapLayer and adds it using plugin', async () => {
+    const newLayer = { id: 'layer_2' };
+    layerManager.add(newLayer);
+    const layer = layerManager.layers[1];
+    layer.layerType = 'success';
+
+    expect(layer.mapLayer).toBeUndefined();
+
+    layerManager.requestLayer(layer);
+
+    // we need to await the promise before doing assertions within a callback.
+    await layerManager.promises[layer.id];
+
+    expect(layerManager.requestCancel).toHaveBeenCalledWith(layer.id);
+    expect(TestPlugin.prototype.add).toHaveBeenCalledWith(layer, layerManager.layers);
+    expect(TestPlugin.prototype.setZIndex).toHaveBeenCalledWith(layer, layer.zIndex);
+    expect(TestPlugin.prototype.setOpacity).toHaveBeenCalledWith(layer, layer.opacity);
+    expect(TestPlugin.prototype.setVisibility).toHaveBeenCalledWith(layer, layer.visibility);
+    expect(layer.mapLayer.id).toMatch('YET_ANOTHER_MAP_LAYER');
+  });
+});

--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -94,7 +94,7 @@ class LayerManager {
       this.plugin.setOpacity(layerModel, opacity);
     }
     if (typeof visibility !== 'undefined') {
-      this.plugin.setOpacity(layerModel, !visibility ? 0 : layerModel.opacity);
+      this.plugin.setVisibility(layerModel, visibility);
     }
     if (typeof zIndex !== 'undefined') {
       this.plugin.setZIndex(layerModel, zIndex);

--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -15,12 +15,19 @@ function checkPluginProperties(plugin) {
       'setParams',
       'setSQLParams',
       'setDecodeParams',
-      'getLayerByProvider'
+      'getLayerByType'
     ];
 
     requiredProperties.forEach(property => {
       if (!plugin[property]) {
         console.error(`The ${property} function is required for layer manager plugins`);
+      }
+    });
+
+    const deprecatedProperties = ['getLayerByProvider'];
+    deprecatedProperties.forEach(property => {
+      if (plugin[property]) {
+        console.error(`The ${property} function is deprecated for layer manager plugins`);
       }
     });
   }
@@ -61,7 +68,9 @@ class LayerManager {
     const layerModel = new LayerModel({ ...layer, ...layerOptions });
     const { id } = layerModel;
 
-    if (this.layers.find(l => l.id === id)) return this.layers;
+    if (this.layers.find(l => l.id === id)) {
+      return this.layers;
+    }
     this.layers.push(layerModel);
 
     this.requestLayer(layerModel);
@@ -91,7 +100,9 @@ class LayerManager {
       this.plugin.setZIndex(layerModel, zIndex);
     }
 
-    if (!isEmpty(decodeParams)) this.plugin.setDecodeParams(layerModel);
+    if (!isEmpty(decodeParams)) {
+      this.plugin.setDecodeParams(layerModel);
+    }
   }
 
   /**
@@ -165,13 +176,12 @@ class LayerManager {
     // Cancel previous/existing request
     this.requestCancel(layerModel.id);
 
-    // every render method returns a promise that we store in the array
+    // every request method returns a promise that we store in the array
     // to control when all layers are fetched.
     this.promises[layerModel.id] = method.call(this, layerModel).then(layer => {
       const { _canceled: canceled } = this.promises[layerModel.id];
       if (!canceled) {
         layerModel.set('mapLayer', layer);
-
         this.plugin.add(layerModel, this.layers);
         this.plugin.setZIndex(layerModel, layerModel.zIndex);
         this.plugin.setOpacity(layerModel, layerModel.opacity);

--- a/src/utils/__tests__/vector-style-layers.js
+++ b/src/utils/__tests__/vector-style-layers.js
@@ -1,4 +1,4 @@
-import { getVectorStyleLayers } from '../vector-style-layers';
+import { getVectorStyleLayers } from 'utils/vector-style-layers';
 
 describe('Returns mountable layers with id and opacity applied', () => {
   const LAYER_MODEL = { id: 1234, opacity: 0.5 };

--- a/src/utils/__tests__/vector-style-layers.js
+++ b/src/utils/__tests__/vector-style-layers.js
@@ -1,0 +1,79 @@
+import { getVectorStyleLayers } from '../vector-style-layers';
+
+describe('Returns mountable layers with id and opacity applied', () => {
+  const LAYER_MODEL = { id: 1234, opacity: 0.5 };
+  const VECTOR_LAYER = {
+    paint: {
+      'fill-color': '#ee9587',
+      'fill-opacity': 0.7
+    },
+    'source-layer': 'layer0',
+    type: 'fill'
+  };
+
+  it('returns false when no vectorLayers provided', () => {
+    const noVectorLayers = getVectorStyleLayers(null, LAYER_MODEL);
+    const emptyVectorLayers = getVectorStyleLayers([], LAYER_MODEL);
+
+    expect(noVectorLayers).toBe(false);
+    expect(emptyVectorLayers).toBe(false);
+  });
+
+  it('returns an id, layer source and layer model opacity applied up to 0.99', () => {
+    const [layer] = getVectorStyleLayers([VECTOR_LAYER], LAYER_MODEL);
+    expect(layer).toEqual({
+      ...VECTOR_LAYER,
+      source: LAYER_MODEL.id,
+      id: `${LAYER_MODEL.id}-${VECTOR_LAYER.type}-0`,
+      paint: {
+        ...VECTOR_LAYER.paint,
+        'fill-opacity': VECTOR_LAYER.paint['fill-opacity'] * LAYER_MODEL.opacity * 0.99
+      }
+    });
+  });
+
+  it('sets null and undefined paint opacity props as 1', () => {
+    const nullFillOpacityLayer = {
+      ...VECTOR_LAYER,
+      paint: {
+        ...VECTOR_LAYER.paint,
+        'fill-opacity': null
+      }
+    };
+
+    const undefinedFillOpacityLayer = {
+      ...VECTOR_LAYER,
+      paint: {
+        ...VECTOR_LAYER.paint,
+        'fill-opacity': undefined
+      }
+    };
+    const [layer0, layer1] = getVectorStyleLayers(
+      [nullFillOpacityLayer, undefinedFillOpacityLayer],
+      LAYER_MODEL
+    );
+
+    expect(layer0.paint['fill-opacity']).toBe(LAYER_MODEL.opacity * 0.99);
+    expect(layer1.paint['fill-opacity']).toBe(LAYER_MODEL.opacity * 0.99);
+  });
+
+  it('removes paint props that are falsy', () => {
+    const falsyPaintPropsLayer = {
+      ...VECTOR_LAYER,
+      paint: {
+        ...VECTOR_LAYER.paint,
+        'plain-false': false,
+        'falsy-because-zero': 0, // is this the expected behaviour?
+        'falsy-because-nan': NaN,
+        'falsy-because-null': null,
+        'falsy-because-undefined': undefined
+      }
+    };
+
+    const [layer] = getVectorStyleLayers([falsyPaintPropsLayer], LAYER_MODEL);
+    expect(layer.paint).toEqual({
+      ...VECTOR_LAYER.paint,
+      'fill-opacity': VECTOR_LAYER.paint['fill-opacity'] * LAYER_MODEL.opacity * 0.99
+    });
+  });
+});

--- a/src/utils/vector-style-layers.js
+++ b/src/utils/vector-style-layers.js
@@ -12,37 +12,38 @@ export const getVectorStyleLayers = (vectorLayers, layerModel) => {
     const vectorLayersParsed = JSON.parse(replace(JSON.stringify(vectorLayers), params, sqlParams));
     return (
       vectorLayersParsed &&
-      vectorLayersParsed.map((l, i) => {
+      vectorLayersParsed.map((vectorLayer, i) => {
         const PAINT_STYLE_NAMES = {
           symbol: ['icon', 'text'],
           circle: ['circle', 'circle-stroke']
         };
 
         // Select the paint property from the original layer
-        const { paint = {} } = l;
+        const { paint = {} } = vectorLayer;
 
         // Select the style to change depending on the type of layer
-        const opacityPaintNames = PAINT_STYLE_NAMES[l.type] || [l.type];
+        const opacityPaintNames = PAINT_STYLE_NAMES[vectorLayer.type] || [vectorLayer.type];
 
         const opacityPaintStyles = opacityPaintNames.reduce((obj, name) => {
           const currentProperty = paint[`${name}-opacity`];
-          const paintOpacity = currentProperty !== undefined ? currentProperty : 1;
 
+          const paintOpacity =
+            currentProperty !== undefined && currentProperty !== null ? currentProperty : 1;
           return {
             ...obj,
             [`${name}-opacity`]: paintOpacity * layerModel.opacity * 0.99
           };
         }, {});
 
-        // if paint properties or null are passed it breaks interaction
+        // if paint properties are null are passed it breaks interaction
         // on mapbox. We need to remove these
         const filteredPaintProperties =
-          l.paint &&
-          Object.entries(l.paint).reduce(
-            (obj, arr) => ({
+          vectorLayer.paint &&
+          Object.entries(vectorLayer.paint).reduce(
+            (obj, [key, value]) => ({
               ...obj,
-              ...(!!arr[1] && {
-                [arr[0]]: arr[1]
+              ...(!!value && {
+                [key]: value
               })
             }),
             {}
@@ -51,10 +52,10 @@ export const getVectorStyleLayers = (vectorLayers, layerModel) => {
         return {
           // id: This will avoid having issues with any layer, but you should specify an id when you create it.
           // If you don't set an id in the definition, and you set a fill-opacity, it won't work
-          id: `${id}-${l.type}-${i}`,
-          ...l,
+          id: `${id}-${vectorLayer.type}-${i}`,
+          ...vectorLayer,
           source: id,
-          ...(l.paint && {
+          ...(vectorLayer.paint && {
             paint: {
               ...filteredPaintProperties,
               ...opacityPaintStyles


### PR DESCRIPTION
_Please review and merge after #72 and #73_

This PR adds more tests. I found some weird use cases that commented on the tests. I think I found and fixed one bug at `utils/vector-styles-layers.js`.

I think I also found another bug in the layer manager core, for some reason we're using `plugin.setOpacity` to toggle the visibility withing the `update` method. I think this is wrong, because it's not compatible with Leaflet and IMO is responsibility of the plugin not the core. Also it seems weird to have it done in that way in `update` and not in `setVisibility`. Finally I think, this also loses the original opacity of the layer once you toggle it to hidden and then back to visible.

**P.S. I don't have access to the settings repo, therefore can't set up the CI on travis or whatever. Would be good to set that up with a coverage bot as well..**