### PR TITLE
remove .__deck check that prevents layers to be on the correct zIndex

### DIFF
--- a/src/layer-manager.js
+++ b/src/layer-manager.js
@@ -27,7 +27,7 @@ function checkPluginProperties(plugin) {
     const deprecatedProperties = ['getLayerByProvider'];
     deprecatedProperties.forEach(property => {
       if (plugin[property]) {
-        console.error(`The ${property} function is deprecated for layer manager plugins`);
+        console.warn(`The ${property} function is deprecated for layer manager plugins`);
       }
     });
   }

--- a/src/plugins/plugin-mapbox-gl/index.js
+++ b/src/plugins/plugin-mapbox-gl/index.js
@@ -195,7 +195,7 @@ class PluginMapboxGL {
     // set for all decode layers that don't exist inside mapStyle()
     const decodeLayers = allLayers.filter(l => !!l.decodeFunction);
 
-    if (decodeLayers && this.map && this.map.__deck && this.map.__deck.layerManager) {
+    if (decodeLayers && this.map) {
       decodeLayers.forEach(layerModel => {
         const { mapLayer } = layerModel;
 


### PR DESCRIPTION
We don't know why `this.map.__deck && this.map.__deck.layerManager` was there. If I reload my page it seems that decode layers won't be on the correct zIndex. If I remove it, everything is working... 

@edbrett @andresgnlez Could you test it on your projects before merging?