### PR TITLE
Add type prop to the Layer table in the migration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ The LayerManager component API specification hasn't changed a lot so start with 
 | id                                                                         | id                                                                                             |
 | ❌ layerConfig                                                             | ✅source                                                                                       |
 | -                                                                          | ✅render                                                                                       |
+- | ✅ type
 | params                                                                     | params                                                                                         |
 | sqlParams                                                                  | sqlParams                                                                                      |
 | decodeParams                                                               | decodeParams                                                                                   |


### PR DESCRIPTION
I forgot about the `type` prop in the `<Layer />` component table for the migration section overview, this PR adds it.