### PR TITLE
Feature/update deck utils

### DIFF
--- a/src/plugins/plugin-mapbox-gl/custom-layers/mapbox-layer/deck-utils.js
+++ b/src/plugins/plugin-mapbox-gl/custom-layers/mapbox-layer/deck-utils.js
@@ -168,8 +168,6 @@ function afterRender(deck, map) {
       return true;
     });
     if (layers.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log('afterRender');
       deck._drawLayers('mapbox-repaint', {
         viewports: [getViewport(deck, map, false)],
         layers,


### PR DESCRIPTION
Updates the `deck-utils` file for the DeckGL mapbox layer to the latest version and maintains previous customisations. This solves a bug sometimes visible where `getLayers()` could not be called due to DeckGL's internal layer manager not yet being defined.