### PR TITLE
Remove deprecated dependency "viewport-mercator-project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Using yarn:
 You should also install these packages versions to have everything working
 - `deck.gl@7.3.6`
 - `luma.gl@7.3.2`
-- `viewport-mercator-project@6.1.1`
 - `axios`
 
 

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "rollup-plugin-babel": "3.0.7",
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-node-resolve": "^3.3.0",
-    "rollup-plugin-terser": "^4.0.2",
-    "viewport-mercator-project": "6.1.1"
+    "rollup-plugin-terser": "^4.0.2"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ const globals = {
   earcut: 'earcut',
   '@mapbox/tiny-sdf': '@mapbox/tiny-sdf',
   'deck.gl': 'deck.gl',
-  'luma.gl': 'luma.gl',
+  'luma.gl': 'luma.gl'
 };
 const external = Object.keys(globals);
 const babelOptions = () => ({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,6 @@ const globals = {
   '@mapbox/tiny-sdf': '@mapbox/tiny-sdf',
   'deck.gl': 'deck.gl',
   'luma.gl': 'luma.gl',
-  'viewport-mercator-project': 'viewport-mercator-project'
 };
 const external = Object.keys(globals);
 const babelOptions = () => ({

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@math.gl/web-mercator": "^3.3.2",
     "classnames": "^2.2.6",
     "d3-ease": "^1.0.5",
     "deck.gl": "7.3.6",
@@ -19,7 +20,6 @@
     "react-dom": "^16.9.0",
     "react-map-gl": "^5.2.3",
     "react-scripts": "3.1.1",
-    "viewport-mercator-project": "6.1.1",
     "vizzuality-components": "^3.0.0-beta.9"
   },
   "scripts": {

--- a/sandbox/src/components/map/index.js
+++ b/sandbox/src/components/map/index.js
@@ -239,9 +239,9 @@ class Map extends Component {
       height: this.mapContainer.offsetHeight,
       bounds: [
         [bbox[0], bbox[1]],
-        [bbox[2], bbox[3]],
+        [bbox[2], bbox[3]]
       ],
-      ...options,
+      ...options
     });
 
     const newViewport = {

--- a/sandbox/src/components/map/index.js
+++ b/sandbox/src/components/map/index.js
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
 
 import ReactMapGL, { FlyToInterpolator, TRANSITION_EVENTS } from 'react-map-gl';
-import WebMercatorViewport from 'viewport-mercator-project';
+import { fitBounds } from '@math.gl/web-mercator';
 
 import { easeCubic } from 'd3-ease';
 
@@ -231,23 +231,18 @@ class Map extends Component {
   };
 
   fitBounds = () => {
-    const { viewport } = this.state;
     const { bounds, onViewportChange } = this.props;
-    const { bbox, options } = bounds;
+    const { bbox, options, viewportOptions } = bounds;
 
-    const v = {
+    const { longitude, latitude, zoom } = fitBounds({
       width: this.mapContainer.offsetWidth,
       height: this.mapContainer.offsetHeight,
-      ...viewport
-    };
-
-    const { longitude, latitude, zoom } = new WebMercatorViewport(v).fitBounds(
-      [
+      bounds: [
         [bbox[0], bbox[1]],
-        [bbox[2], bbox[3]]
+        [bbox[2], bbox[3]],
       ],
-      options
-    );
+      ...options,
+    });
 
     const newViewport = {
       ...this.state.viewport,
@@ -255,7 +250,8 @@ class Map extends Component {
       latitude,
       zoom,
       transitionDuration: 2500,
-      transitionInterruption: TRANSITION_EVENTS.UPDATE
+      transitionInterruption: TRANSITION_EVENTS.UPDATE,
+      ...viewportOptions
     };
 
     this.setState({

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -1490,6 +1490,14 @@
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"
 
+"@math.gl/web-mercator@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz#e85e4efab8c74edd549f20121ba680b0f466e9cd"
+  integrity sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    gl-matrix "^3.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -11135,14 +11143,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-viewport-mercator-project@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#d7b2cb3cb772b819f1daab17cf4019102a9102a6"
-  integrity sha512-nI0GEmXnESwZxWSJuaQkdCnvOv6yckUfqqFbNB8KWVbQY3eUExVM4ZziqCVVs5mNznLjDF1auj6HLW5D5DKcng==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    gl-matrix "^3.0.0"
 
 viewport-mercator-project@^6.1.0:
   version "6.2.3"

--- a/src/plugins/plugin-mapbox-gl/custom-layers/tile-layer/utils/viewport-util.js
+++ b/src/plugins/plugin-mapbox-gl/custom-layers/tile-layer/utils/viewport-util.js
@@ -12,11 +12,11 @@ function lngLatToWorld([lng, lat], scale) {
     return console.error('lngLatToWorld: lng, lat or scale are not correct values');
   }
 
-  const s = (TILE_SIZE * 2) * scale;
+  const s = TILE_SIZE * 2 * scale;
   const lambda2 = lng * DEGREES_TO_RADIANS;
   const phi2 = lat * DEGREES_TO_RADIANS;
-  const x = s * (lambda2 + PI) / (2 * PI);
-  const y = s * (PI - Math.log(Math.tan(PI_4 + phi2 * 0.5))) / (2 * PI);
+  const x = (s * (lambda2 + PI)) / (2 * PI);
+  const y = (s * (PI - Math.log(Math.tan(PI_4 + phi2 * 0.5)))) / (2 * PI);
   return [x, y];
 }
 function getBoundingBox(viewport) {

--- a/src/plugins/plugin-mapbox-gl/custom-layers/tile-layer/utils/viewport-util.js
+++ b/src/plugins/plugin-mapbox-gl/custom-layers/tile-layer/utils/viewport-util.js
@@ -1,7 +1,24 @@
-import { lngLatToWorld } from 'viewport-mercator-project';
-
 const TILE_SIZE = 256;
+const { PI } = Math;
+const PI_4 = PI / 4;
+const DEGREES_TO_RADIANS = PI / 180;
 
+function lngLatToWorld([lng, lat], scale) {
+  if (
+    !Number.isFinite(lng) ||
+    !Number.isFinite(scale) ||
+    !(Number.isFinite(lat) && lat >= -90 && lat <= 90)
+  ) {
+    return console.error('lngLatToWorld: lng, lat or scale are not correct values');
+  }
+
+  const s = (TILE_SIZE * 2) * scale;
+  const lambda2 = lng * DEGREES_TO_RADIANS;
+  const phi2 = lat * DEGREES_TO_RADIANS;
+  const x = s * (lambda2 + PI) / (2 * PI);
+  const y = s * (PI - Math.log(Math.tan(PI_4 + phi2 * 0.5))) / (2 * PI);
+  return [x, y];
+}
 function getBoundingBox(viewport) {
   const corners = [
     viewport.unproject([0, 0]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,14 +6296,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viewport-mercator-project@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#d7b2cb3cb772b819f1daab17cf4019102a9102a6"
-  integrity sha512-nI0GEmXnESwZxWSJuaQkdCnvOv6yckUfqqFbNB8KWVbQY3eUExVM4ZziqCVVs5mNznLjDF1auj6HLW5D5DKcng==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    gl-matrix "^3.0.0"
-
 viewport-mercator-project@^6.1.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.2.3.tgz#4122040f51ef9553fa41a46bcc6502977b3909c6"


### PR DESCRIPTION
This PR removes `viewport-mercator-project` from layer-manager dependencies. It also changes the `viewport-mercator-project` sandbox dependency to `@math.gl/web-mercator`