### PR TITLE
Fix: decoded raster layers update via setProps

### DIFF
--- a/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
@@ -168,7 +168,6 @@ const Template: Story<LayerProps> = (args: any) => {
             <Layer
               {...args}
               deck={DECK_LAYERS}
-              decodeParams={decodeParams}
             />
           </LayerManager>
         )}

--- a/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 // Layer manager
 import { LayerManager, Layer, LayerProps } from '@vizzuality/layer-manager-react';
@@ -76,13 +76,17 @@ const Template: Story<LayerProps> = (args: any) => {
           tileSize: 256,
           visible: true,
           refinementStrategy: 'no-overlap',
+          decodeParams,
+          decodeFunction,
           renderSubLayers: (sl) => {
             const {
               id: subLayerId,
               data,
               tile,
               visible,
-              opacity
+              opacity,
+              decodeFunction: dFunction,
+              decodeParams: dParams
             } = sl;
 
             const {
@@ -106,11 +110,12 @@ const Template: Story<LayerProps> = (args: any) => {
                 zoom: z,
                 visible,
                 opacity,
-                decodeParams: decodeParams || {
-                  startYear: 2001,
-                  endYear: 2017,
-                },
-                decodeFunction
+                decodeParams: dParams,
+                decodeFunction: dFunction,
+                updateTriggers: {
+                  decodeParams: dParams,
+                  decodeFunction: dFunction,
+                }
               });
             }
             return null;
@@ -126,11 +131,18 @@ const Template: Story<LayerProps> = (args: any) => {
     setViewport(vw);
   }, []);
 
+  useEffect(() => {
+    const [layer] = DECK_LAYERS;
+    if (layer && typeof layer.setProps === 'function') {
+      layer.setProps({
+        decodeParams,
+        decodeFunction,
+      });
+    }
+  }, [decodeParams, decodeFunction])
+
   return (
     <div
-      key={JSON.stringify({
-        id, tileUrl, decodeFunction, decodeParams
-      })}
       style={{
         position: 'relative',
         width: '100%',

--- a/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/biomass.stories.tsx
@@ -58,7 +58,7 @@ export default {
 };
 
 const Template: Story<LayerProps> = (args: any) => {
-  const { id, tileUrl, decodeFunction, decodeParams } = args;
+  const { tileUrl, decodeFunction, decodeParams } = args;
 
   const minZoom = 2;
   const maxZoom = 20;

--- a/applications/docs/src/stories/playground/decoded-raster-layer/default.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/default.stories.tsx
@@ -191,7 +191,6 @@ const Template: Story<LayerProps> = (args: any) => {
             <Layer
               {...args}
               deck={DECK_LAYERS}
-              decodeParams={decodeParams}
             />
           </LayerManager>
         )}

--- a/applications/docs/src/stories/playground/decoded-raster-layer/default.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/default.stories.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 // Layer manager
 import { LayerManager, Layer, LayerProps } from '@vizzuality/layer-manager-react';
@@ -107,7 +107,8 @@ const Template: Story<LayerProps> = (args: any) => {
               tile,
               visible,
               opacity,
-              decodeParams,
+              decodeParams: dParams,
+              decodeFunction: dFunction,
             } = sl;
 
             const {
@@ -131,11 +132,12 @@ const Template: Story<LayerProps> = (args: any) => {
                 zoom: z,
                 visible,
                 opacity,
-                decodeParams: decodeParams || {
-                  startYear: 2001,
-                  endYear: 2017,
+                decodeParams: dParams,
+                decodeFunction: dFunction,
+                updateTriggers: {
+                  decodeParams: dParams,
+                  decodeFunction: dFunction,
                 },
-                decodeFunction
               });
             }
             return null;
@@ -151,11 +153,19 @@ const Template: Story<LayerProps> = (args: any) => {
     setViewport(vw);
   }, []);
 
+  useEffect(() => {
+    const [layer] = DECK_LAYERS;
+    if (layer && typeof layer.setProps === 'function') {
+      layer.setProps({
+        decodeParams,
+        decodeFunction,
+      });
+    }
+  }, [decodeParams, decodeFunction])
+
+
   return (
     <div
-      key={JSON.stringify({
-        id, tileUrl, decodeFunction, decodeParams
-      })}
       style={{
         position: 'relative',
         width: '100%',

--- a/applications/docs/src/stories/playground/decoded-raster-layer/dominant-driver.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/dominant-driver.stories.tsx
@@ -222,7 +222,6 @@ const Template: Story<LayerProps> = (args: any) => {
             <Layer
               {...args}
               deck={DECK_LAYERS}
-              decodeParams={decodeParams}
             />
           </LayerManager>
         )}

--- a/applications/docs/src/stories/playground/decoded-raster-layer/dominant-driver.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/dominant-driver.stories.tsx
@@ -111,7 +111,7 @@ export default {
 };
 
 const Template: Story<LayerProps> = (args: any) => {
-  const { id, tileUrl, decodeFunction, decodeParams } = args;
+  const { tileUrl, decodeFunction, decodeParams } = args;
 
   const minZoom = 2;
   const maxZoom = 20;

--- a/applications/docs/src/stories/playground/decoded-raster-layer/glad.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/glad.stories.tsx
@@ -193,7 +193,6 @@ const Template: Story<LayerProps> = (args: any) => {
             <Layer
               {...args}
               deck={DECK_LAYERS}
-              decodeParams={decodeParams}
             />
           </LayerManager>
         )}

--- a/applications/docs/src/stories/playground/decoded-raster-layer/glad.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/glad.stories.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 // Layer manager
 import { LayerManager, Layer, LayerProps } from '@vizzuality/layer-manager-react';
@@ -83,7 +83,7 @@ export default {
 };
 
 const Template: Story<LayerProps> = (args: any) => {
-  const { id, tileUrl, decodeFunction, decodeParams } = args;
+  const { tileUrl, decodeFunction, decodeParams } = args;
 
   const minZoom = 2;
   const maxZoom = 20;
@@ -101,13 +101,17 @@ const Template: Story<LayerProps> = (args: any) => {
           tileSize: 256,
           visible: true,
           refinementStrategy: 'no-overlap',
+          decodeFunction,
+          decodeParams,
           renderSubLayers: (sl) => {
             const {
               id: subLayerId,
               data,
               tile,
               visible,
-              opacity
+              opacity,
+              decodeFunction: dFunction,
+              decodeParams: dParams
             } = sl;
 
             const {
@@ -131,11 +135,12 @@ const Template: Story<LayerProps> = (args: any) => {
                 zoom: z,
                 visible,
                 opacity,
-                decodeParams: decodeParams || {
-                  startYear: 2001,
-                  endYear: 2017,
+                decodeParams: dParams,
+                decodeFunction: dFunction,
+                updateTriggers: {
+                  decodeParams: dParams,
+                  decodeFunction: dFunction,
                 },
-                decodeFunction
               });
             }
             return null;
@@ -151,11 +156,18 @@ const Template: Story<LayerProps> = (args: any) => {
     setViewport(vw);
   }, []);
 
+  useEffect(() => {
+    const [layer] = DECK_LAYERS;
+    if (layer && typeof layer.setProps === 'function') {
+      layer.setProps({
+        decodeParams,
+        decodeFunction
+      });
+    }
+  }, [decodeParams, decodeFunction])
+
   return (
     <div
-      key={JSON.stringify({
-        id, tileUrl, decodeFunction, decodeParams
-      })}
       style={{
         position: 'relative',
         width: '100%',

--- a/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 // Layer manager
 import { LayerManager, Layer, LayerProps } from '@vizzuality/layer-manager-react';
@@ -28,7 +28,7 @@ export default {
     tileUrl: {
       name: 'tileUrl',
       type: { name: 'Tile URL', required: true },
-      defaultValue: 'https://tiles.globalforestwatch.org/tsc_tree_cover_loss_drivers/v2020/tcd_30/{z}/{x}/{y}.png',
+      defaultValue: 'https://tiles.globalforestwatch.org/gfw_integrated_alerts/latest/default/{z}/{x}/{y}.png',
       control: {
         type: 'text'
       },
@@ -37,71 +37,71 @@ export default {
       name: 'decodeParams',
       type: { name: 'object', required: true },
       defaultValue: {
-        startYear: 2001,
-        endYear: 2017,
+        startDayIndex: 0,
+        endDayIndex: 1150,
       }
     },
     decodeFunction: {
       name: 'decodeFunction',
       type: { name: 'string', required: true },
       defaultValue: `
-      float year = 2000.0 + (color.b * 255.);
-      // map to years
-      if (year >= startYear && year <= endYear && year >= 2001.) {
-        // values for creating power scale, domain (input), and range (output)
-        float domainMin = 0.;
-        float domainMax = 255.;
-        float rangeMin = 0.;
-        float rangeMax = 255.;
 
-        float exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;
-        float intensity = color.r * 255.;
+  // First 6 bits Alpha channel used to individual alert confidence
+  // First two bits (leftmost) are GLAD-L
+  // Next, 3rd and 4th bits are GLAD-S2
+  // Finally, 5th and 6th bits are RADD
+  // Bits are either: 00 (0, no alerts), 01 (1, low conf), or 10 (2, high conf)
+  // e.g. 00 10 01 00 --> no GLAD-L, high conf GLAD-S2, low conf RADD
 
-        // get the min, max, and current values on the power scale
-        float minPow = pow(domainMin, exponent - domainMin);
-        float maxPow = pow(domainMax, exponent);
-        float currentPow = pow(intensity, exponent);
+  float agreementValue = alpha * 255.;
 
-        // get intensity value mapped to range
-        float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
+  float r = color.r * 255.;
+  float g = color.g * 255.;
+  float b = color.b * 255.;
 
-        // a value between 0 and 255
-        alpha = scaleIntensity * 2. / 255.;
-        float lossCat = color.g * 255.;
+  float day = r * 255. + g;
+  float confidence = floor(b / 100.) - 1.;
+  float intensity = mod(b, 100.) * 50.;
 
-        float r = 255.;
-        float g = 255.;
-        float b = 255.;
+  if (
+    day > 0. &&
+    day >= startDayIndex &&
+    day <= endDayIndex &&
+    agreementValue > 0.
+  )
+  {
+    if (intensity > 255.) {
+      intensity = 255.;
+    }
+    // get high and highest confidence alerts
+    float confidenceValue = 0.;
 
-        if (lossCat == 1.) {
-          r = 244.;
-          g = 29.;
-          b = 54.;
-        } else if (lossCat == 2.) {
-          r = 239.;
-          g = 211.;
-          b = 26.;
-        } else if (lossCat == 3.) {
-          r = 47.;
-          g = 191.;
-          b = 113.;
-        } else if (lossCat == 4.) {
-          r = 173.;
-          g = 104.;
-          b = 36.;
-        } else if (lossCat == 5.) {
-          r = 178.;
-          g = 53.;
-          b = 204.;
-        }
+    if (agreementValue == 4. || agreementValue == 16. || agreementValue == 64.) {
+      // ONE ALERT LOW CONF: 4,8,16,32,64,128 i.e. 2**(2+n) for n<8
 
-        color.r = r / 255.;
-        color.g = g / 255.;
-        color.b = b / 255.;
-      } else {
-        alpha = 0.;
-      }
-    `,
+      color.r = 237. / 255.;
+      color.g = 164. / 255.;
+      color.b = 194. / 255.;
+      alpha = (intensity -confidenceValue) / 255.;
+    } else if (agreementValue == 8. || agreementValue == 32. || agreementValue ==  128.){
+      // ONE HIGH CONF ALERT: 8,32,128 i.e. 2**(2+n) for n<8 and odd
+
+      color.r = 220. / 255.;
+      color.g = 102. / 255.;
+      color.b = 153. / 255.;
+      alpha = intensity / 255.;
+    } else {
+      // MULTIPLE ALERTS: >0 and not 2**(2+n)
+
+      color.r = 201. / 255.;
+      color.g = 42. / 255.;
+      color.b = 109. / 255.;
+      alpha = intensity / 255.;
+    }
+  } else {
+    alpha = 0.;
+  }
+      `,
       description: 'The decode function you will apply to each tile pixel',
       control: {
         type: 'text'
@@ -123,19 +123,23 @@ const Template: Story<LayerProps> = (args: any) => {
     return [
       new MapboxLayer(
         {
-          id:'tcl-by-dominant-driver',
+          id:'integrated',
           type: TileLayer,
           data: tileUrl,
           tileSize: 256,
           visible: true,
           refinementStrategy: 'no-overlap',
+          decodeFunction,
+          decodeParams,
           renderSubLayers: (sl) => {
             const {
               id: subLayerId,
               data,
               tile,
               visible,
-              opacity
+              opacity,
+              decodeFunction: dFunction,
+              decodeParams: dParams
             } = sl;
 
             const {
@@ -159,11 +163,12 @@ const Template: Story<LayerProps> = (args: any) => {
                 zoom: z,
                 visible,
                 opacity,
-                decodeParams: decodeParams || {
-                  startYear: 2001,
-                  endYear: 2017,
+                decodeParams: dParams,
+                decodeFunction: dFunction,
+                updateTriggers: {
+                  decodeParams: dParams,
+                  decodeFunction: dFunction,
                 },
-                decodeFunction
               });
             }
             return null;
@@ -179,11 +184,19 @@ const Template: Story<LayerProps> = (args: any) => {
     setViewport(vw);
   }, []);
 
+  useEffect(() => {
+    const [layer] = DECK_LAYERS;
+    if (layer && typeof layer.setProps === 'function') {
+      layer.setProps({
+        decodeParams,
+        decodeFunction
+      });
+    }
+  }, [decodeParams, decodeFunction])
+
+
   return (
     <div
-      key={JSON.stringify({
-        id, tileUrl, decodeFunction, decodeParams
-      })}
       style={{
         position: 'relative',
         width: '100%',
@@ -218,8 +231,8 @@ const Template: Story<LayerProps> = (args: any) => {
   );
 };
 
-export const DominantDriver = Template.bind({});
-DominantDriver.args = {
-  id: 'deck-loss-byDriver-decode',
+export const IntegratedAlerts = Template.bind({});
+IntegratedAlerts.args = {
+  id: 'deck-integrated-alerts-decode',
   type: 'deck'
 };

--- a/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
@@ -222,7 +222,6 @@ const Template: Story<LayerProps> = (args: any) => {
             <Layer
               {...args}
               deck={DECK_LAYERS}
-              decodeParams={decodeParams}
             />
           </LayerManager>
         )}

--- a/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
+++ b/applications/docs/src/stories/playground/decoded-raster-layer/integrated-alerts.stories.tsx
@@ -111,7 +111,7 @@ export default {
 };
 
 const Template: Story<LayerProps> = (args: any) => {
-  const { id, tileUrl, decodeFunction, decodeParams } = args;
+  const { tileUrl, decodeFunction, decodeParams } = args;
 
   const minZoom = 2;
   const maxZoom = 20;

--- a/docs/LAYER-SPEC.md
+++ b/docs/LAYER-SPEC.md
@@ -451,31 +451,6 @@ You will have this result
 }
 ```
 
-#### `decodeParams - (optional) - (object)`
-
-An object that we will use as properties to decode the raster tile images of a layer. The must be numbers, no strings allowed.
-
-`decodeFunction` must be present.
-
-These `decodeParams` will be sent to the `decodeFunction`.
-
-Example:
-
-```json
-{
-  "decodeParams": {
-    "startYear": 2001,
-    "endYear": 2018
-  }
-}
-```
-
-#### `decodeFunction - (optional) - (string)`
-
-A shader that defines how to decode each of the images tiles that comes to a raster layer.
-
-`decodeParams` must be present.
-
 #### `onAfterAdd` - (optional) - (function)
 A function that will be triggered after you add a layer. It doesn't mean that the layer tiles are loaded, it means that the layer is ready for consumption for things like adding interactivity, reading source, etc...
 

--- a/docs/REACT-INTEGRATION.md
+++ b/docs/REACT-INTEGRATION.md
@@ -34,54 +34,6 @@ const activeLayers = [
     }
   },
 
-  // DECODED RASTER LAYER
-  {
-    id: 'loss',
-    type: 'raster',
-    source: {
-      type: 'raster',
-      tiles: [
-        `https://storage.googleapis.com/wri-public/Hansen_16/tiles/hansen_world/v1/tc30/{z}/{x}/{y}.png`
-      ],
-      minzoom: 3,
-      maxzoom: 12
-    },
-    decodeParams: {
-      startYear: 2001,
-      endYear: 2018
-    },
-    decodeFunction: `
-      // values for creating power scale, domain (input), and range (output)
-      float domainMin = 0.;
-      float domainMax = 255.;
-      float rangeMin = 0.;
-      float rangeMax = 255.;
-
-      float exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;
-      float intensity = color.r * 255.;
-
-      // get the min, max, and current values on the power scale
-      float minPow = pow(domainMin, exponent - domainMin);
-      float maxPow = pow(domainMax, exponent);
-      float currentPow = pow(intensity, exponent);
-
-      // get intensity value mapped to range
-      float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
-      // a value between 0 and 255
-      alpha = zoom < 13. ? scaleIntensity / 255. : color.g;
-
-      float year = 2000.0 + (color.b * 255.);
-      // map to years
-      if (year >= startYear && year <= endYear && year >= 2001.) {
-        color.r = 220. / 255.;
-        color.g = (72. - zoom + 102. - 3. * scaleIntensity / zoom) / 255.;
-        color.b = (33. - zoom + 153. - intensity / zoom) / 255.;
-      } else {
-        alpha = 0.;
-      }
-    `
-  },
-
   // GEOJSON DATA LAYER
   {
     id: 'multipolygon',

--- a/packages/core/src/layer-manager.ts
+++ b/packages/core/src/layer-manager.ts
@@ -69,7 +69,6 @@ class LayerManager {
       render,
       params,
       sqlParams,
-      decodeParams,
     } = newLayerSpec;
 
     if (typeof opacity !== 'undefined') {
@@ -98,10 +97,6 @@ class LayerManager {
 
     if (!isEmpty(sqlParams)) {
       this._plugin.setSQLParams(layerModel);
-    }
-
-    if (!isEmpty(decodeParams)) {
-      this._plugin.setDecodeParams(layerModel);
     }
   }
 

--- a/packages/core/src/layer-model.ts
+++ b/packages/core/src/layer-model.ts
@@ -77,16 +77,8 @@ class LayerModel {
     return this._layerSpec.params;
   }
 
-  public get decodeParams(): LayerSpec['decodeParams'] {
-    return this._layerSpec.decodeParams;
-  }
-
   public get sqlParams(): LayerSpec['sqlParams'] {
     return this._layerSpec.sqlParams;
-  }
-
-  public get decodeFunction(): LayerSpec['decodeFunction'] {
-    return this._layerSpec.decodeFunction;
   }
 
   public get deck(): LayerSpec['deck'] {

--- a/packages/core/tests/layer-manager.test_.js
+++ b/packages/core/tests/layer-manager.test_.js
@@ -113,7 +113,6 @@ describe('Core layer manager', () => {
       opacity: 1,
       visibility: true,
       zIndex: 0,
-      decodeParams: { stuff: [] },
     };
 
     layerManager.update('layer_0', changedProps);
@@ -146,25 +145,6 @@ describe('Core layer manager', () => {
       ...originalLayer,
       ...changedProps,
       mapLayer,
-      // does it makes sense to save the data? Perhaps only the keys are needed?
-      changedAttributes: changedProps,
-    });
-  });
-
-  it('updates only the decodeParams', () => {
-    const originalLayer = { ...layerManager.layers[0] };
-    const changedProps = {
-      decodeParams: { key: 'someParams' },
-    };
-    layerManager.update('layer_1', changedProps);
-
-    expect(TestPlugin.prototype.setZIndex).not.toHaveBeenCalled();
-    expect(TestPlugin.prototype.setOpacity).not.toHaveBeenCalled();
-    expect(TestPlugin.prototype.setVisibility).not.toHaveBeenCalled();
-
-    expect(layerManager.layers[0]).toEqual({
-      ...originalLayer,
-      ...changedProps,
       // does it makes sense to save the data? Perhaps only the keys are needed?
       changedAttributes: changedProps,
     });

--- a/packages/core/tests/layer-manager.test_.js
+++ b/packages/core/tests/layer-manager.test_.js
@@ -12,7 +12,6 @@ TestPlugin.prototype.setRender = jest.fn();
 TestPlugin.prototype.setVisibility = jest.fn();
 TestPlugin.prototype.setOpacity = jest.fn();
 TestPlugin.prototype.setZIndex = jest.fn();
-TestPlugin.prototype.setDecodeParams = jest.fn();
 TestPlugin.prototype.getLayerByType = jest.fn().mockImplementation((type) => {
   if (type !== 'success') {
     return () => ({
@@ -37,7 +36,6 @@ describe('Core layer manager', () => {
     TestPlugin.prototype.setVisibility.mockClear();
     TestPlugin.prototype.setOpacity.mockClear();
     TestPlugin.prototype.setZIndex.mockClear();
-    TestPlugin.prototype.setDecodeParams.mockClear();
     TestPlugin.prototype.getLayerByType.mockClear();
     layerManager.requestCancel.mockClear();
   });
@@ -123,7 +121,6 @@ describe('Core layer manager', () => {
     expect(TestPlugin.prototype.setZIndex).not.toHaveBeenCalled();
     expect(TestPlugin.prototype.setOpacity).not.toHaveBeenCalled();
     expect(TestPlugin.prototype.setVisibility).not.toHaveBeenCalled();
-    expect(TestPlugin.prototype.setDecodeParams).not.toHaveBeenCalled();
   });
 
   it('updates the layer and tracks changes in changedAttributes', () => {
@@ -144,7 +141,6 @@ describe('Core layer manager', () => {
 
     // This seems to be a bug, it's not consistent.
     expect(TestPlugin.prototype.setVisibility).toHaveBeenCalled();
-    expect(TestPlugin.prototype.setDecodeParams).not.toHaveBeenCalled();
 
     expect(layerManager.layers[0]).toEqual({
       ...originalLayer,
@@ -165,7 +161,6 @@ describe('Core layer manager', () => {
     expect(TestPlugin.prototype.setZIndex).not.toHaveBeenCalled();
     expect(TestPlugin.prototype.setOpacity).not.toHaveBeenCalled();
     expect(TestPlugin.prototype.setVisibility).not.toHaveBeenCalled();
-    expect(TestPlugin.prototype.setDecodeParams).toHaveBeenCalled();
 
     expect(layerManager.layers[0]).toEqual({
       ...originalLayer,

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -50,7 +50,6 @@ export type Params = Record<string, string | number | boolean | unknown>;
  * keys should start by 'where' or 'and'
  */
 export type SQLParams = Record<string, Params>;
-export type DecodeParams = Record<string, number>;
 
 /**
  * Documentation for images on MapboxGL
@@ -71,8 +70,6 @@ export type LayerSpec = {
   images?: Image[]
   params?: Params
   sqlParams?: SQLParams
-  decodeParams?: DecodeParams
-  decodeFunction?: string
   source: Source
   render?: Render
   interactivity?: unknown[]
@@ -102,7 +99,6 @@ export interface Plugin {
   setRender: (layerModel: LayerModel) => void
   setParams: (layerModel: LayerModel) => void
   setSQLParams: (layerModel: LayerModel) => void
-  setDecodeParams: (layerModel: LayerModel) => void
   setDeck: (layerModel: LayerModel) => void
   getLayerByType: (type: LayerModel['type']) => any // TO-DO: better type definition
   getLayerByProvider?: () => void // Deprecated

--- a/packages/layers-deckgl/src/decoded-layer/index.js
+++ b/packages/layers-deckgl/src/decoded-layer/index.js
@@ -103,7 +103,7 @@ export default class DecodedLayer extends Layer {
 
   updateState({ props, oldProps, changeFlags }) {
     // setup model first
-    if (changeFlags.extensionsChanged) {
+    if (changeFlags.extensionsChanged || changeFlags.somethingChanged.decodeFunction) {
       const { gl } = this.context;
       this.state.model?.delete();
       this.state.model = this._getModel(gl);

--- a/packages/plugin-mapboxgl/src/index.js
+++ b/packages/plugin-mapboxgl/src/index.js
@@ -442,26 +442,6 @@ class PluginMapboxGL {
     return this;
   }
 
-  setDecodeParams(layerModel) {
-    const { mapLayer, decodeParams } = layerModel;
-
-    if (!mapLayer) {
-      return this;
-    }
-
-    const layer = mapLayer.layers[1];
-
-    if (layer && typeof layer.setProps === 'function') {
-      layer.setProps({ decodeParams });
-    } else {
-      console.error(
-        "Layer is not present. You defined decodeParams but maybe you didn't define a decodeFunction",
-      );
-    }
-
-    return this;
-  }
-
   setDeck() {
     return this;
   }

--- a/packages/plugin-mapboxgl/types.d.ts
+++ b/packages/plugin-mapboxgl/types.d.ts
@@ -10,6 +10,5 @@ interface Plugin {
   setRender: () => void
   setParams: () => void
   setSQLParams: () => void
-  setDecodeParams: () => void
   getLayerByType: () => void
 }

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -13,7 +13,6 @@ class Layer extends PureComponent<LayerProps> {
   static defaultProps = {
     params: undefined,
     sqlParams: undefined,
-    decodeParams: undefined,
     opacity: 1,
     visibility: true,
     zIndex: undefined,

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -32,7 +32,6 @@ class Layer extends PureComponent<LayerProps> {
       render: prevRender,
       params: prevParams,
       sqlParams: prevSqlParams,
-      decodeParams: prevDecodeParams,
       opacity: prevOpacity,
       visibility: prevVisibility,
       zIndex: prevZIndex,
@@ -44,7 +43,6 @@ class Layer extends PureComponent<LayerProps> {
       render,
       params,
       sqlParams,
-      decodeParams,
       opacity,
       visibility,
       zIndex,
@@ -110,9 +108,6 @@ class Layer extends PureComponent<LayerProps> {
       }),
       ...(!isEqual(renderParsed, prevRenderParsed) && {
         render: renderParsed,
-      }),
-      ...(!isEqual(decodeParams, prevDecodeParams) && {
-        decodeParams,
       }),
     };
 


### PR DESCRIPTION
Remove `decodeParams` and `decodeFunction` from layer-manager core. As they are properties from deck.gl you can directly use them in the decodedRasterLayer from `@vizzuality/layer-manager-layers-deckgl`. 

Check the examples

- [x] Remove docs
- [x] Remove dependencies